### PR TITLE
Store model text in memory

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyInterface.java
@@ -20,6 +20,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.Collection;
+import java.util.Map;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.lsp.ext.LspLog;
 import software.amazon.smithy.model.Model;
@@ -43,13 +44,7 @@ public final class SmithyInterface {
   public static Either<Exception, ValidatedResult<Model>> readModel(Collection<File> files,
       Collection<File> externalJars) {
     try {
-      URL[] urls = externalJars.stream().map(SmithyInterface::fileToUrl).toArray(URL[]::new);
-      URLClassLoader urlClassLoader = new URLClassLoader(urls);
-      ModelAssembler assembler = Model.assembler(urlClassLoader)
-              .discoverModels(urlClassLoader)
-              // We don't want the model to be broken when there are unknown traits,
-              // because that will essentially disable language server features.
-              .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
+      ModelAssembler assembler = getModelAssembler(externalJars);
 
       for (File file : files) {
         assembler.addImport(file.getAbsolutePath());
@@ -60,6 +55,40 @@ public final class SmithyInterface {
       LspLog.println(e);
       return Either.forLeft(e);
     }
+  }
+
+  /**
+   * Reads in the specified model files, adding external jars to model builder.
+   *
+   * @param sources Map of model file URIs to their contents
+   * @param externalJars set of external jars
+   * @return either an exception encountered during model building, or the result
+   *         of model building
+   */
+  public static Either<Exception, ValidatedResult<Model>> readModel(
+          Map<String, String> sources,
+          Collection<File> externalJars
+  ) {
+    try {
+      ModelAssembler assembler = getModelAssembler(externalJars);
+      for (String uri : sources.keySet()) {
+        assembler.addUnparsedModel(uri, sources.get(uri));
+      }
+      return Either.forRight(assembler.assemble());
+    } catch (Exception e) {
+      LspLog.println(e);
+      return Either.forLeft(e);
+    }
+  }
+
+  private static ModelAssembler getModelAssembler(Collection<File> externalJars) {
+    URL[] urls = externalJars.stream().map(SmithyInterface::fileToUrl).toArray(URL[]::new);
+    URLClassLoader urlClassLoader = new URLClassLoader(urls);
+    return Model.assembler(urlClassLoader)
+            .discoverModels(urlClassLoader)
+            // We don't want the model to be broken when there are unknown traits,
+            // because that will essentially disable language server features.
+            .putProperty(ModelAssembler.ALLOW_UNKNOWN_TRAITS, true);
   }
 
   private static URL fileToUrl(File file) {

--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -124,15 +124,7 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
 
   @Override
   public TextDocumentService getTextDocumentService() {
-    File temp = null;
-    try {
-      temp = Files.createTempDirectory("smithy-lsp").toFile();
-      LspLog.println("Created a temporary folder for file contents " + temp);
-      temp.deleteOnExit();
-    } catch (IOException e) {
-      LspLog.println("Failed to create a temporary folder " + e);
-    }
-    SmithyTextDocumentService local = new SmithyTextDocumentService(this.client, temp);
+    SmithyTextDocumentService local = new SmithyTextDocumentService(this.client);
     tds = Optional.of(local);
     return local;
   }

--- a/src/main/java/software/amazon/smithy/lsp/diagnostics/VersionDiagnostics.java
+++ b/src/main/java/software/amazon/smithy/lsp/diagnostics/VersionDiagnostics.java
@@ -17,6 +17,7 @@ package software.amazon.smithy.lsp.diagnostics;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -93,10 +94,10 @@ public final class VersionDiagnostics {
      * @param temporaryContents a map of file to content (represent opened file that are not saved)
      * @return a list of PublishDiagnosticsParams
      */
-    public static List<Diagnostic> createVersionDiagnostics(File f, Map<File, String> temporaryContents) {
+    public static List<Diagnostic> createVersionDiagnostics(File f, Map<URI, String> temporaryContents) {
         // number of line to read in which we expect the $version statement
         int n = 5;
-        String editedContent = temporaryContents.get(f);
+        String editedContent = temporaryContents.get(f.toURI());
 
         List<Utils.NumberedLine> lines;
         try {

--- a/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/Completions.java
@@ -41,6 +41,7 @@ import software.amazon.smithy.model.shapes.TimestampShape;
 import software.amazon.smithy.model.shapes.UnionShape;
 import software.amazon.smithy.model.traits.RequiredTrait;
 import software.amazon.smithy.model.traits.TraitDefinition;
+import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.utils.ListUtils;
 
 public final class Completions {
@@ -52,18 +53,26 @@ public final class Completions {
     }
 
     /**
-     * From a model and (potentially partial) token, build a list of completions.
-     * Empty list is returned for empty tokens. Current implementation is prefix
-     * based.
+     * From a model validation result and (potentially partial) token, build a list of completions.
+     * Empty list is returned for empty tokens, or if the model validation result doesn't contain a model. Current
+     * implementation is prefix based.
      *
-     * @param model Smithy model
+     * @param modelValidatedResult Smithy model validation result
      * @param token token
      * @param isTraitShapeId boolean
      * @param target Optional ShapeId of the target trait target
      * @return list of completion items
      */
-    public static List<SmithyCompletionItem> find(Model model, String token, boolean isTraitShapeId,
-                                                  Optional<ShapeId> target) {
+    public static List<SmithyCompletionItem> find(
+            ValidatedResult<Model> modelValidatedResult,
+            String token,
+            boolean isTraitShapeId,
+            Optional<ShapeId> target
+    ) {
+        if (!modelValidatedResult.getResult().isPresent()) {
+            return ListUtils.of();
+        }
+        Model model = modelValidatedResult.getResult().get();
         Map<String, SmithyCompletionItem> comps = new HashMap<>();
         String lcase = token.toLowerCase();
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
@@ -350,13 +350,7 @@ final class FileCachingCollector implements ShapeLocationCollector {
     }
 
     private static String getUri(String fileName) {
-        return Utils.isJarFile(fileName)
-                ? Utils.toSmithyJarFile(fileName)
-                : addFilePrefix(fileName);
-    }
-
-    private static String addFilePrefix(String fileName) {
-        return !fileName.startsWith("file:") ? "file:" + fileName : fileName;
+        return Utils.createUri(fileName).toString();
     }
 
     private static List<String> getAllFilenamesFromModel(Model model) {

--- a/src/test/java/software/amazon/smithy/lsp/DefinitionProviderTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/DefinitionProviderTest.java
@@ -157,9 +157,9 @@ public class DefinitionProviderTest {
         Path model = rootDir.resolve(filename);
         try (Harness hs = Harness.builder().paths(model).build()) {
             StubClient client = new StubClient();
-            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.of(client), hs.getTempFolder());
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.of(client));
             tds.setProject(hs.getProject());
-            TextDocumentIdentifier tdi = new TextDocumentIdentifier(hs.file(filename).toString());
+            TextDocumentIdentifier tdi = new TextDocumentIdentifier(hs.file(filename).toURI().toString());
             DefinitionParams params = getDefinitionParams(tdi, line, column);
             try {
                 return tds.definition(params).get().getLeft();

--- a/src/test/java/software/amazon/smithy/lsp/HoverProviderTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/HoverProviderTest.java
@@ -238,9 +238,9 @@ public class HoverProviderTest {
         paths.add(rootDir.resolve(filename));
         try (Harness hs = builder.paths(paths).build()) {
             StubClient client = new StubClient();
-            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.of(client), hs.getTempFolder());
+            SmithyTextDocumentService tds = new SmithyTextDocumentService(Optional.of(client));
             tds.setProject(hs.getProject());
-            TextDocumentIdentifier tdi = new TextDocumentIdentifier(hs.file(filename).toString());
+            TextDocumentIdentifier tdi = new TextDocumentIdentifier(hs.file(filename).toURI().toString());
 
             HoverParams params = new HoverParams(tdi, new Position(line, column));
             try {

--- a/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/Harness.java
@@ -21,14 +21,11 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import software.amazon.smithy.cli.dependencies.DependencyResolver;
-import software.amazon.smithy.cli.dependencies.ResolvedArtifact;
 import software.amazon.smithy.lsp.Utils;
 import software.amazon.smithy.lsp.ext.model.SmithyBuildExtensions;
 import software.amazon.smithy.utils.IoUtils;
@@ -62,7 +59,6 @@ public class Harness implements AutoCloseable {
   public SmithyBuildExtensions getConfig() {
     return this.config;
   }
-
 
   public File file(String path) {
     return Paths.get(root.getAbsolutePath(), path).toFile();
@@ -155,17 +151,13 @@ public class Harness implements AutoCloseable {
     }
   }
 
-  private static Harness loadHarness(
-          SmithyBuildExtensions ext,
-          File hs,
-          File tmp,
-          DependencyResolver resolver
-  ) throws Exception {
-    Either<Exception, SmithyProject> loaded = SmithyProject.load(ext, hs, resolver);
-    if (loaded.isRight())
-      return new Harness(hs, tmp, loaded.getRight(), ext);
-    else
-      throw loaded.getLeft();
+  private static Harness loadHarness(SmithyBuildExtensions ext, File hs, File tmp, DependencyResolver resolver) {
+    SmithyProject loaded = SmithyProject.load(ext, hs, resolver);
+    if (!loaded.isBroken()) {
+      return new Harness(hs, tmp, loaded, ext);
+    } else {
+      throw new RuntimeException(String.join("\n", loaded.getErrors()));
+    }
   }
 
   private static void safeCreateFile(String path, String contents, File root) throws Exception {


### PR DESCRIPTION
This is primarily a refactor of SmithyProject to store raw model text in memory. Previously, we only stored file objects for the model, and gave those to the model assembler. There are two issues with this approach:
1. While a file is being editted, the source of truth for the file contents should be what the client sends back to the server in the `didChange` event, not whats actually in the file. To get around this, we've been using a temporary file that stores the contents of the file being editted, and giving that to the model assembler. When publishing diagnostics however, we needed to re-map the file location from the temporary file to the actual file on disk.
2. The language server needs literal text to provide some of its features, meaning we need to read in files frequently.

These changes update SmithyProject to store a map of URI -> String for each of the model files in the loaded model by walking the shapes and collecting all unique file locations. SmithyTDS is updated to use that when it needs to have literal text of the model for formatting, version diagnostics, and other features.

Various other updates were also made:
- Added a list of errors to SmithyProject that store any errors that occur while loading the project. Previously, any "load" methods would return `Either<Exception, SmithyProject>`, which isn't very ergonomic to use. These errors represent failures in the project loading, not validation errors from loading the model.
- SmithyProject's loading methods are reworked to provide 2 static methods: one for loading the project in a directory, one for loading from specific smithy-build config, and 2 instance methods: one for regular reloading, one for reloading with specific file changes. Previously, we had to manage the loading of the temporary file (or its removal). This also moves all the loading logic into SmithyProject.
- String-literal uris are replaced with URI class since LSP guarantees uris will be valid (see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#uri).
- SmithyInterface has new method to load from text-literal sources.
- Completions updated to handle invalid model result, so callers don't have to. This allows removing `getCompletions` from SmithyProject.
- Various access modifiers adjusted to be more strict, tightening the API to make it easier for us to change implementations.

The following test updates were made:
- Added multiple test cases for different project loading & reloading situations.
- Some tests needed to use URI class instead of uri strings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
