### PR TITLE
Add setting to enable logging to file

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -15,6 +15,7 @@
 
 package software.amazon.smithy.lsp;
 
+import com.google.gson.JsonObject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -84,6 +85,18 @@ public class SmithyLanguageServer implements LanguageServer, LanguageClientAware
         params.setWorkspaceFolders(ListUtils.of(workspaceFolder));
       } catch (IOException e) {
         e.printStackTrace();
+      }
+    }
+
+    // TODO: Replace with a Gson Type Adapter if more config options are added beyond `logToFile`.
+    Object initializationOptions = params.getInitializationOptions();
+    if (initializationOptions instanceof JsonObject) {
+      JsonObject jsonObject = (JsonObject) initializationOptions;
+      if (jsonObject.has("logToFile")) {
+        String setting = jsonObject.get("logToFile").getAsString();
+        if (setting.equals("enabled")) {
+          LspLog.enable();
+        }
       }
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/LspLog.java
@@ -39,6 +39,7 @@ import software.amazon.smithy.utils.ListUtils;
 public final class LspLog {
     private static FileWriter fw = null;
     private static Optional<List<Object>> buffer = Optional.of(new ArrayList<>());
+    private static boolean enabled = false;
 
     private LspLog() {
     }
@@ -70,6 +71,10 @@ public final class LspLog {
      * @param folder workspace folder where log file will be created
      */
     public static void setWorkspaceFolder(File folder) {
+        if (!enabled) {
+            return;
+        }
+
         try {
             fw = new FileWriter(Paths.get(folder.getAbsolutePath(), "/.smithy.lsp.log").toFile());
             synchronized (buffer) {
@@ -82,6 +87,13 @@ public final class LspLog {
 
     }
 
+    /**
+     * Enables writing LspLog to a file.
+     */
+    public static void enable() {
+        enabled = true;
+    }
+
     private static String currentTime() {
         return LocalTime.now().withNano(0).format(DateTimeFormatter.ISO_LOCAL_TIME);
     }
@@ -92,6 +104,9 @@ public final class LspLog {
      * @param message object to write, will be converted to String
      */
     public static void println(Object message) {
+        if (!enabled) {
+            return;
+        }
         String sanitizedMessage = getStringifiedMessage(message);
         String timestamped = "[" + currentTime() + "] " + sanitizedMessage;
         try {


### PR DESCRIPTION
This adds a "lspLog" initialization option which controls whether log files are written to `.smithy.lsp.log` in the client's workspace. By default, this log file will be disabled. Setting the option to `enabled` will enable writing the log file.

Closes #123.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
