### PR TITLE
Avoid substring if not suffixed

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
+++ b/src/main/java/software/amazon/smithy/lsp/ext/FileCachingCollector.java
@@ -240,7 +240,10 @@ final class FileCachingCollector implements ShapeLocationCollector {
             String suffix = getOperationInputOrOutputSuffix(shape, preamble);
             String shapeName = shape.getId().getName();
 
-            String matchingOperationName = shapeName.substring(0, shapeName.length() - suffix.length());
+            String matchingOperationName =
+                shapeName.endsWith(suffix)
+                    ? shapeName.substring(0, shapeName.length() - suffix.length())
+                    : shapeName;
             ShapeId matchingOperationId = ShapeId.fromParts(shape.getId().getNamespace(), matchingOperationName);
 
             return model.shapes(OperationShape.class)

--- a/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/ext/SmithyProjectTest.java
@@ -493,6 +493,14 @@ public class SmithyProjectTest {
                     new Position(160,8)).get());
             assertEquals(ShapeId.from("com.example#OtherStructure"), project.getShapeIdFromLocation(testUri,
                     new Position(7, 15)).get());
+            assertEquals(ShapeId.from("com.foo#ShortI"), project.getShapeIdFromLocation(uri,
+                new Position(210,5)).get());
+            assertEquals(ShapeId.from("com.foo#ShortI$c"), project.getShapeIdFromLocation(uri,
+                new Position(211,6)).get());
+            assertEquals(ShapeId.from("com.foo#ShortO"), project.getShapeIdFromLocation(uri,
+                new Position(215,5)).get());
+            assertEquals(ShapeId.from("com.foo#ShortO$d"), project.getShapeIdFromLocation(uri,
+                new Position(216,6)).get());
         }
     }
 

--- a/src/test/resources/software/amazon/smithy/lsp/ext/models/v2/main.smithy
+++ b/src/test/resources/software/amazon/smithy/lsp/ext/models/v2/main.smithy
@@ -201,3 +201,18 @@ structure FalseInlinedReversedBarOutput {
 
 @trait
 structure emptyTraitStruct {}
+
+operation ShortInputOutput {
+    output: ShortO
+    input: ShortI
+}
+
+@input
+structure ShortI {
+    c: String
+}
+
+@output
+structure ShortO {
+    d: String
+}


### PR DESCRIPTION
*Issue #, if available:*

Fixes #132 

*Description of changes:*

Avoid the string manipulation if the shape name is not suffixed by input or ouput.