### PR TITLE
Prevent the automated workflow from running in fork

### DIFF
--- a/.github/workflows/update-smithy-version.yml
+++ b/.github/workflows/update-smithy-version.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   get-version:
     runs-on: ubuntu-latest
+    if: github.repository == "smithy-lang/smithy-language-server"
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
*Issue #, if available:*

No issue available, but when forking this workflow we end up with a scheduled workflow that runs but w/o the token. 

*Description of changes:*

Make the job conditional on whether or not it is executing from _this_ repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
