### PR TITLE
Use smithy official formatter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,8 +159,8 @@ dependencies {
     implementation "org.eclipse.lsp4j:org.eclipse.lsp4j:0.14.0"
     implementation "software.amazon.smithy:smithy-build:[smithyVersion, 2.0["
     implementation "software.amazon.smithy:smithy-cli:[smithyVersion, 2.0["
+    implementation "software.amazon.smithy:smithy-syntax:[smithyVersion, 2.0["
     implementation "software.amazon.smithy:smithy-model:[smithyVersion, 2.0["
-    implementation 'com.disneystreaming.smithy:smithytranslate-formatter-jvm-java-api:0.3.10'
 
     // Use JUnit test framework
     testImplementation "junit:junit:4.13"


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

We've implemented support for formatting via the [formatter in smithy-translate](https://github.com/disneystreaming/smithy-translate/tree/main/modules/formatter) but now that the official formatter is out, there is no reason not to use it.

In my own tests, the official formatter produce different results but it is more consistent. Our modeling of the AST is wrong when it comes to whitespaces and as such we produce poorly formatted files when comments are extensively used. For example, [this recent issue](https://github.com/disneystreaming/smithy-translate/issues/226#issuecomment-1898543615) highlight a simple snippet that is poorly formatted. The official formatter does the correct thing here.

I'd be happy to add some tests if you like this PR. Feel free to push changes to this PR if you want to do it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
