### PR TITLE
Add support for multiple workspaces

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -33,9 +33,12 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -50,14 +53,13 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
-import org.eclipse.lsp4j.FileChangeType;
-import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.InitializeParams;
@@ -82,7 +84,11 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.WorkDoneProgressBegin;
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
 import org.eclipse.lsp4j.WorkDoneProgressEnd;
+import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.WorkspaceFoldersOptions;
+import org.eclipse.lsp4j.WorkspaceServerCapabilities;
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -102,7 +108,7 @@ import software.amazon.smithy.lsp.handler.DefinitionHandler;
 import software.amazon.smithy.lsp.handler.FileWatcherRegistrationHandler;
 import software.amazon.smithy.lsp.handler.HoverHandler;
 import software.amazon.smithy.lsp.project.Project;
-import software.amazon.smithy.lsp.project.ProjectConfigLoader;
+import software.amazon.smithy.lsp.project.ProjectChanges;
 import software.amazon.smithy.lsp.project.ProjectLoader;
 import software.amazon.smithy.lsp.project.ProjectManager;
 import software.amazon.smithy.lsp.project.SmithyFile;
@@ -133,6 +139,11 @@ public class SmithyLanguageServer implements
         capabilities.setHoverProvider(true);
         capabilities.setDocumentFormattingProvider(true);
         capabilities.setDocumentSymbolProvider(true);
+
+        WorkspaceFoldersOptions workspaceFoldersOptions = new WorkspaceFoldersOptions();
+        workspaceFoldersOptions.setSupported(true);
+        capabilities.setWorkspace(new WorkspaceServerCapabilities(workspaceFoldersOptions));
+
         CAPABILITIES = capabilities;
     }
 
@@ -145,17 +156,12 @@ public class SmithyLanguageServer implements
     SmithyLanguageServer() {
     }
 
-    SmithyLanguageServer(LanguageClient client, Project project) {
-        this.client = new SmithyLanguageClient(client);
-        this.projects.updateMainProject(project);
-    }
-
     SmithyLanguageClient getClient() {
         return this.client;
     }
 
-    Project getProject() {
-        return projects.mainProject();
+    Project getFirstProject() {
+        return projects.nonDetachedProjects().values().stream().findFirst().orElse(null);
     }
 
     ProjectManager getProjects() {
@@ -212,22 +218,8 @@ public class SmithyLanguageServer implements
             }
         }
 
-        Path root = null;
-        // TODO: Handle multiple workspaces
-        if (params.getWorkspaceFolders() != null && !params.getWorkspaceFolders().isEmpty()) {
-            String uri = params.getWorkspaceFolders().get(0).getUri();
-            root = Paths.get(URI.create(uri));
-        } else if (params.getRootUri() != null) {
-            String uri = params.getRootUri();
-            root = Paths.get(URI.create(uri));
-        } else if (params.getRootPath() != null) {
-            String uri = params.getRootPath();
-            root = Paths.get(URI.create(uri));
-        }
 
-        if (root != null) {
-            // TODO: Support this for other tasks. Need to create a progress token with the client
-            //  through createProgress.
+        if (params.getWorkspaceFolders() != null && !params.getWorkspaceFolders().isEmpty()) {
             Either<String, Integer> workDoneProgressToken = params.getWorkDoneToken();
             if (workDoneProgressToken != null) {
                 WorkDoneProgressBegin notification = new WorkDoneProgressBegin();
@@ -235,7 +227,10 @@ public class SmithyLanguageServer implements
                 client.notifyProgress(new ProgressParams(workDoneProgressToken, Either.forLeft(notification)));
             }
 
-            tryInitProject(root);
+            for (WorkspaceFolder workspaceFolder : params.getWorkspaceFolders()) {
+                Path root = Paths.get(URI.create(workspaceFolder.getUri()));
+                tryInitProject(workspaceFolder.getName(), root);
+            }
 
             if (workDoneProgressToken != null) {
                 WorkDoneProgressEnd notification = new WorkDoneProgressEnd();
@@ -247,15 +242,15 @@ public class SmithyLanguageServer implements
         return completedFuture(new InitializeResult(CAPABILITIES));
     }
 
-    private void tryInitProject(Path root) {
+    private void tryInitProject(String name, Path root) {
         LOGGER.info("Initializing project at " + root);
         lifecycleManager.cancelAllTasks();
         Result<Project, List<Exception>> loadResult = ProjectLoader.load(
                 root, projects, lifecycleManager.managedDocuments());
         if (loadResult.isOk()) {
             Project updatedProject = loadResult.unwrap();
-            resolveDetachedProjects(updatedProject);
-            projects.updateMainProject(loadResult.unwrap());
+            resolveDetachedProjects(this.projects.getProjectByName(name), updatedProject);
+            this.projects.updateProjectByName(name, updatedProject);
             LOGGER.info("Initialized project at " + root);
         } else {
             LOGGER.severe("Init project failed");
@@ -263,11 +258,11 @@ public class SmithyLanguageServer implements
             //  if we find a smithy-build.json, etc.
             // If we overwrite an existing project with an empty one, we lose track of the state of tracked
             // files. Instead, we will just keep the original project before the reload failure.
-            if (projects.mainProject() == null) {
-                projects.updateMainProject(Project.empty(root));
+            if (projects.getProjectByName(name) == null) {
+                projects.updateProjectByName(name, Project.empty(root));
             }
 
-            String baseMessage = "Failed to load Smithy project at " + root;
+            String baseMessage = "Failed to load Smithy project " + name + " at " + root;
             StringBuilder errorMessage = new StringBuilder(baseMessage).append(":");
             for (Exception error : loadResult.unwrapErr()) {
                 errorMessage.append(System.lineSeparator());
@@ -281,11 +276,11 @@ public class SmithyLanguageServer implements
         }
     }
 
-    private void resolveDetachedProjects(Project updatedProject) {
+    private void resolveDetachedProjects(Project oldProject, Project updatedProject) {
         // This is a project reload, so we need to resolve any added/removed files
         // that need to be moved to or from detached projects.
-        if (getProject() != null) {
-            Set<String> currentProjectSmithyPaths = getProject().smithyFiles().keySet();
+        if (oldProject != null) {
+            Set<String> currentProjectSmithyPaths = oldProject.smithyFiles().keySet();
             Set<String> updatedProjectSmithyPaths = updatedProject.smithyFiles().keySet();
 
             Set<String> addedPaths = new HashSet<>(updatedProjectSmithyPaths);
@@ -303,8 +298,7 @@ public class SmithyLanguageServer implements
                 String removedUri = LspAdapter.toUri(removedPath);
                 // Only move to a detached project if the file is managed
                 if (lifecycleManager.managedDocuments().contains(removedUri)) {
-                    // Note: This should always be non-null, since we essentially got this from the current project
-                    Document removedDocument = projects.getDocument(removedUri);
+                    Document removedDocument = oldProject.getDocument(removedUri);
                     // The copy here is technically unnecessary, if we make ModelAssembler support borrowed strings
                     projects.createDetachedProject(removedUri, removedDocument.copyText());
                 }
@@ -313,8 +307,8 @@ public class SmithyLanguageServer implements
     }
 
     private CompletableFuture<Void> registerSmithyFileWatchers() {
-        Project project = projects.mainProject();
-        List<Registration> registrations = FileWatcherRegistrationHandler.getSmithyFileWatcherRegistrations(project);
+        List<Registration> registrations = FileWatcherRegistrationHandler.getSmithyFileWatcherRegistrations(
+                projects.nonDetachedProjects().values());
         return client.registerCapability(new RegistrationParams(registrations));
     }
 
@@ -325,7 +319,8 @@ public class SmithyLanguageServer implements
 
     @Override
     public void initialized(InitializedParams params) {
-        List<Registration> registrations = FileWatcherRegistrationHandler.getBuildFileWatcherRegistrations();
+        List<Registration> registrations = FileWatcherRegistrationHandler.getBuildFileWatcherRegistrations(
+                projects.nonDetachedProjects().values());
         client.registerCapability(new RegistrationParams(registrations));
         registerSmithyFileWatchers();
     }
@@ -365,7 +360,6 @@ public class SmithyLanguageServer implements
         }
     }
 
-    // TODO: This doesn't really work for multiple projects
     @Override
     public CompletableFuture<List<? extends Location>> selectorCommand(SelectorParams selectorParams) {
         LOGGER.info("SelectorCommand");
@@ -378,29 +372,31 @@ public class SmithyLanguageServer implements
             return completedFuture(Collections.emptyList());
         }
 
-        Project project = projects.mainProject();
-        // TODO: Might also want to tell user if the model isn't loaded
-        // TODO: Use proper location (source is just a point)
-        return completedFuture(project.modelResult().getResult()
+        // Select from all available projects
+        Collection<Project> detached = projects.detachedProjects().values();
+        Collection<Project> nonDetached = projects.nonDetachedProjects().values();
+
+        return completedFuture(Stream.concat(detached.stream(), nonDetached.stream())
+                .flatMap(project -> project.modelResult().getResult().stream())
                 .map(selector::select)
-                .map(shapes -> shapes.stream()
+                .flatMap(shapes -> shapes.stream()
+                        // TODO: Use proper location (source is just a point)
                         .map(Shape::getSourceLocation)
-                        .map(LspAdapter::toLocation)
-                        .collect(Collectors.toList()))
-                .orElse(Collections.emptyList()));
+                        .map(LspAdapter::toLocation))
+                .toList());
     }
 
     @Override
     public CompletableFuture<ServerStatus> serverStatus() {
-        OpenProject openProject = new OpenProject(
-                LspAdapter.toUri(projects.mainProject().root().toString()),
-                projects.mainProject().smithyFiles().keySet().stream()
-                        .map(LspAdapter::toUri)
-                        .collect(Collectors.toList()),
-                false);
-
         List<OpenProject> openProjects = new ArrayList<>();
-        openProjects.add(openProject);
+        for (Project project : projects.nonDetachedProjects().values()) {
+            openProjects.add(new OpenProject(
+                    LspAdapter.toUri(project.root().toString()),
+                    project.smithyFiles().keySet().stream()
+                            .map(LspAdapter::toUri)
+                            .toList(),
+                    false));
+        }
 
         for (Map.Entry<String, Project> entry : projects.detachedProjects().entrySet()) {
             openProjects.add(new OpenProject(
@@ -417,46 +413,72 @@ public class SmithyLanguageServer implements
         LOGGER.info("DidChangeWatchedFiles");
         // Smithy files were added or deleted to watched sources/imports (specified by smithy-build.json),
         // or the smithy-build.json itself was changed
-        Set<String> createdSmithyFiles = new HashSet<>(params.getChanges().size());
-        Set<String> deletedSmithyFiles = new HashSet<>(params.getChanges().size());
-        boolean changedBuildFiles = false;
-        for (FileEvent event : params.getChanges()) {
-            String changedUri = event.getUri();
-            if (changedUri.endsWith(".smithy")) {
-                if (event.getType().equals(FileChangeType.Created)) {
-                    createdSmithyFiles.add(changedUri);
-                } else if (event.getType().equals(FileChangeType.Deleted)) {
-                    deletedSmithyFiles.add(changedUri);
-                }
-            } else if (changedUri.endsWith(ProjectConfigLoader.SMITHY_BUILD)
-                    || changedUri.endsWith(ProjectConfigLoader.SMITHY_PROJECT)) {
-                changedBuildFiles = true;
-            } else {
-                for (String extFile : ProjectConfigLoader.SMITHY_BUILD_EXTS) {
-                    if (changedUri.endsWith(extFile)) {
-                        changedBuildFiles = true;
-                        break;
-                    }
-                }
-            }
-        }
 
-        if (changedBuildFiles) {
-            client.info("Build files changed, reloading project");
-            // TODO: Handle more granular updates to build files.
-            tryInitProject(projects.mainProject().root());
-        } else {
-            client.info("Project files changed, adding files "
-                        + createdSmithyFiles + " and removing files " + deletedSmithyFiles);
-            // We get this notification for watched files, which only includes project files,
-            // so we don't need to resolve detached projects.
-            projects.mainProject().updateFiles(createdSmithyFiles, deletedSmithyFiles);
-        }
+        Map<String, ProjectChanges> changesByProject = projects.computeProjectChanges(params.getChanges());
+
+        changesByProject.forEach((projectName, projectChanges) -> {
+            Project project = projects.getProjectByName(projectName);
+            if (projectChanges.hasChangedBuildFiles()) {
+                client.info("Build files changed, reloading project");
+                // TODO: Handle more granular updates to build files.
+                tryInitProject(projectName, project.root());
+            } else if (projectChanges.hasChangedSmithyFiles()) {
+                Set<String> createdUris = projectChanges.createdSmithyFileUris();
+                Set<String> deletedUris = projectChanges.deletedSmithyFileUris();
+                client.info("Project files changed, adding files "
+                            + createdUris + " and removing files " + deletedUris);
+
+                // We get this notification for watched files, which only includes project files,
+                // so we don't need to resolve detached projects.
+                project.updateFiles(createdUris, deletedUris);
+            }
+        });
 
         // TODO: Update watchers based on specific changes
         unregisterSmithyFileWatchers().thenRun(this::registerSmithyFileWatchers);
 
         sendFileDiagnosticsForManagedDocuments();
+    }
+
+    @Override
+    public void didChangeWorkspaceFolders(DidChangeWorkspaceFoldersParams params) {
+        LOGGER.info("DidChangeWorkspaceFolders");
+
+        Either<String, Integer> progressToken = Either.forLeft(UUID.randomUUID().toString());
+        try {
+            client.createProgress(new WorkDoneProgressCreateParams(progressToken)).get();
+        } catch (ExecutionException | InterruptedException e) {
+            client.error(String.format("Unable to create work done progress token: %s", e.getMessage()));
+            progressToken = null;
+        }
+
+        if (progressToken != null) {
+            WorkDoneProgressBegin begin = new WorkDoneProgressBegin();
+            begin.setTitle("Updating workspace");
+            client.notifyProgress(new ProgressParams(progressToken, Either.forLeft(begin)));
+        }
+
+        for (WorkspaceFolder folder : params.getEvent().getAdded()) {
+            Path root = Paths.get(URI.create(folder.getUri()));
+            tryInitProject(folder.getName(), root);
+        }
+
+        for (WorkspaceFolder folder : params.getEvent().getRemoved()) {
+            Project removedProject = projects.removeProjectByName(folder.getName());
+            if (removedProject == null) {
+                continue;
+            }
+
+            resolveDetachedProjects(removedProject, Project.empty(removedProject.root()));
+        }
+
+        unregisterSmithyFileWatchers().thenRun(this::registerSmithyFileWatchers);
+        sendFileDiagnosticsForManagedDocuments();
+
+        if (progressToken != null) {
+            WorkDoneProgressEnd end = new WorkDoneProgressEnd();
+            client.notifyProgress(new ProgressParams(progressToken, Either.forLeft(end)));
+        }
     }
 
     @Override

--- a/src/main/java/software/amazon/smithy/lsp/project/ProjectChanges.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/ProjectChanges.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.project;
+
+import java.util.Set;
+
+/**
+ * File changes to a {@link Project}.
+ *
+ * @param changedBuildFileUris The uris of changed build files
+ * @param createdSmithyFileUris The uris of created Smithy files
+ * @param deletedSmithyFileUris The uris of deleted Smithy files
+ */
+public record ProjectChanges(
+        Set<String> changedBuildFileUris,
+        Set<String> createdSmithyFileUris,
+        Set<String> deletedSmithyFileUris
+) {
+    /**
+     * @return Whether there are any changed build files
+     */
+    public boolean hasChangedBuildFiles() {
+        return !changedBuildFileUris.isEmpty();
+    }
+
+    /**
+     * @return Whether there are any changed Smithy files
+     */
+    public boolean hasChangedSmithyFiles() {
+        return !createdSmithyFileUris.isEmpty() || !deletedSmithyFileUris.isEmpty();
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/project/ProjectFilePatterns.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/ProjectFilePatterns.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.project;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Utility methods for creating file patterns corresponding to meaningful
+ * paths of a {@link Project}, such as sources and build files.
+ */
+public final class ProjectFilePatterns {
+    private ProjectFilePatterns() {
+    }
+
+    /**
+     * @param project The project to get watch patterns for
+     * @return A list of glob patterns used to watch Smithy files in the given project
+     */
+    public static List<String> getSmithyFileWatchPatterns(Project project) {
+        return Stream.concat(project.sources().stream(), project.imports().stream())
+                .map(path -> getSmithyFilePattern(path, true))
+                .toList();
+    }
+
+    /**
+     * @param project The project to get a path matcher for
+     * @return A path matcher that can check if Smithy files belong to the given project
+     */
+    public static PathMatcher getSmithyFilesPathMatcher(Project project) {
+        String pattern = Stream.concat(project.sources().stream(), project.imports().stream())
+                .map(path -> getSmithyFilePattern(path, false))
+                .collect(Collectors.joining(","));
+        return FileSystems.getDefault().getPathMatcher("glob:{" + pattern + "}");
+    }
+
+    /**
+     * @param project The project to get the watch pattern for
+     * @return A glob pattern used to watch build files in the given project
+     */
+    public static String getBuildFilesWatchPattern(Project project) {
+        Path root = project.root();
+        String smithyBuildJsonPattern = root.resolve(ProjectConfigLoader.SMITHY_BUILD).toString();
+        String smithyProjectJsonPattern = root.resolve(ProjectConfigLoader.SMITHY_PROJECT).toString();
+        List<String> patterns = new ArrayList<>();
+        patterns.add(smithyBuildJsonPattern);
+        patterns.add(smithyProjectJsonPattern);
+        for (String buildExt : ProjectConfigLoader.SMITHY_BUILD_EXTS) {
+            patterns.add(root.resolve(buildExt).toString());
+        }
+
+        return "{" + String.join(",", patterns) + "}";
+    }
+
+    /**
+     * @param project The project to get a path matcher for
+     * @return A path matcher that can check if a file is a build file belonging to the given project
+     */
+    public static PathMatcher getBuildFilesPathMatcher(Project project) {
+        // Watch pattern is the same as the pattern used for matching
+        String pattern = getBuildFilesWatchPattern(project);
+        return FileSystems.getDefault().getPathMatcher("glob:" + pattern);
+    }
+
+    // When computing the pattern used for telling the client which files to watch, we want
+    // to only watch .smithy/.json files. We don't need in the PathMatcher pattern (and it
+    // is impossible anyway because we can't have a nested pattern).
+    private static String getSmithyFilePattern(Path path, boolean isWatcherPattern) {
+        String glob = path.toString();
+        if (glob.endsWith(".smithy") || glob.endsWith(".json")) {
+            return glob;
+        }
+
+        // we have a directory
+        if (glob.endsWith("/")) {
+            glob = glob + "**";
+        } else {
+            glob = glob + "/**";
+        }
+
+        if (isWatcherPattern) {
+            glob += ".{smithy,json}";
+        }
+
+        return glob;
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/project/ProjectFilePatterns.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/ProjectFilePatterns.java
@@ -19,6 +19,8 @@ import java.util.stream.Stream;
  * paths of a {@link Project}, such as sources and build files.
  */
 public final class ProjectFilePatterns {
+    private static final int BUILD_FILE_COUNT = 2 + ProjectConfigLoader.SMITHY_BUILD_EXTS.length;
+
     private ProjectFilePatterns() {
     }
 
@@ -52,7 +54,7 @@ public final class ProjectFilePatterns {
         String buildJsonPattern = escapeBackslashes(root.resolve(ProjectConfigLoader.SMITHY_BUILD).toString());
         String projectJsonPattern = escapeBackslashes(root.resolve(ProjectConfigLoader.SMITHY_PROJECT).toString());
 
-        List<String> patterns = new ArrayList<>();
+        List<String> patterns = new ArrayList<>(BUILD_FILE_COUNT);
         patterns.add(buildJsonPattern);
         patterns.add(projectJsonPattern);
         for (String buildExt : ProjectConfigLoader.SMITHY_BUILD_EXTS) {

--- a/src/main/java/software/amazon/smithy/lsp/project/ProjectManager.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/ProjectManager.java
@@ -5,9 +5,15 @@
 
 package software.amazon.smithy.lsp.project;
 
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
-import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.WorkspaceFolder;
 import software.amazon.smithy.lsp.document.Document;
 import software.amazon.smithy.lsp.protocol.LspAdapter;
 
@@ -16,37 +22,49 @@ import software.amazon.smithy.lsp.protocol.LspAdapter;
  */
 public final class ProjectManager {
     private final Map<String, Project> detached = new HashMap<>();
-    // TODO: Handle multiple main projects
-    private Project mainProject;
+    private final Map<String, Project> projects = new HashMap<>();
 
     public ProjectManager() {
     }
 
     /**
-     * @return The main project (the one with a smithy-build.json). Note that
-     *  this will always be present after
-     *  {@link org.eclipse.lsp4j.services.LanguageServer#initialize(InitializeParams)}
-     *  is called. If there's no smithy-build.json, this is just an empty project.
+     * @param name Name of the project, usually comes from {@link WorkspaceFolder#getName()}
+     * @return The project with the given name, if it exists
      */
-    public Project mainProject() {
-        return mainProject;
+    public Project getProjectByName(String name) {
+        return this.projects.get(name);
     }
 
     /**
-     * @param updated The updated main project. Overwrites existing main project
-     *                without doing a partial update
+     * @param name Name of the project to update
+     * @param updated Project to update
      */
-    public void updateMainProject(Project updated) {
-        this.mainProject = updated;
+    public void updateProjectByName(String name, Project updated) {
+        this.projects.put(name, updated);
     }
 
     /**
-     * @return A map of URIs of open files that aren't attached to the main project
+     * @param name Name of the project to remove
+     * @return The removed project, if it exists
+     */
+    public Project removeProjectByName(String name) {
+        return this.projects.remove(name);
+    }
+
+    /**
+     * @return A map of URIs of open files that aren't attached to a tracked project
      *  to their own detached projects. These projects contain only the file that
      *  corresponds to the key in the map.
      */
     public Map<String, Project> detachedProjects() {
         return detached;
+    }
+
+    /**
+     * @return A map of project names to projects tracked by the server
+     */
+    public Map<String, Project> nonDetachedProjects() {
+        return projects;
     }
 
     /**
@@ -57,12 +75,13 @@ public final class ProjectManager {
         String path = LspAdapter.toPath(uri);
         if (isDetached(uri)) {
             return detached.get(uri);
-        }  else if (mainProject.smithyFiles().containsKey(path)) {
-            return mainProject;
-        } else {
-            // Note: In practice, this shouldn't really happen because the server shouldn't
-            //  be tracking any files that aren't attached to a project. But for testing, this
-            //  is useful to ensure that fact.
+        }  else  {
+            for (Project project : projects.values()) {
+                if (project.smithyFiles().containsKey(path)) {
+                    return project;
+                }
+            }
+
             return null;
         }
     }
@@ -83,16 +102,26 @@ public final class ProjectManager {
      * @return Whether the given {@code uri} is of a file in a detached project
      */
     public boolean isDetached(String uri) {
-        // We might be in a state where a file was added to the main project,
+        // We might be in a state where a file was added to a tracked project,
         // but was opened before the project loaded. This would result in it
         // being placed in a detached project. Removing it here is basically
         // like removing it lazily, although it does feel a little hacky.
         String path = LspAdapter.toPath(uri);
-        if (mainProject.smithyFiles().containsKey(path) && detached.containsKey(uri)) {
+        Project nonDetached = getNonDetached(path);
+        if (nonDetached != null && detached.containsKey(uri)) {
             removeDetachedProject(uri);
         }
 
         return detached.containsKey(uri);
+    }
+
+    private Project getNonDetached(String path) {
+        for (Project project : projects.values()) {
+            if (project.smithyFiles().containsKey(path)) {
+                return project;
+            }
+        }
+        return null;
     }
 
     /**
@@ -125,5 +154,52 @@ public final class ProjectManager {
             return null;
         }
         return project.getDocument(uri);
+    }
+
+    /**
+     * Computes per-project file changes from the given file events.
+     *
+     * @param events The file events to compute per-project file changes from
+     * @return A map of project name to the corresponding project's changes
+     */
+    public Map<String, ProjectChanges> computeProjectChanges(List<FileEvent> events) {
+        // Note: we could eagerly compute these and store them, but project changes are relatively rare,
+        //  and doing it this way means we don't need to manage the state.
+        Map<String, PathMatcher> projectSmithyFileMatchers = new HashMap<>(nonDetachedProjects().size());
+        Map<String, PathMatcher> projectBuildFileMatchers = new HashMap<>(nonDetachedProjects().size());
+
+        Map<String, ProjectChanges> changes = new HashMap<>(nonDetachedProjects().size());
+
+        nonDetachedProjects().forEach((projectName, project) -> {
+            projectSmithyFileMatchers.put(projectName, ProjectFilePatterns.getSmithyFilesPathMatcher(project));
+            projectBuildFileMatchers.put(projectName, ProjectFilePatterns.getBuildFilesPathMatcher(project));
+
+            // Need these to be hash sets so they are mutable
+            changes.put(projectName, new ProjectChanges(new HashSet<>(), new HashSet<>(), new HashSet<>()));
+        });
+
+        for (FileEvent event : events) {
+            String changedUri = event.getUri();
+            Path changedPath = Path.of(LspAdapter.toPath(changedUri));
+            if (changedUri.endsWith(".smithy")) {
+                projectSmithyFileMatchers.forEach((projectName, matcher) -> {
+                    if (matcher.matches(changedPath)) {
+                        if (event.getType() == FileChangeType.Created) {
+                            changes.get(projectName).createdSmithyFileUris().add(changedUri);
+                        } else if (event.getType() == FileChangeType.Deleted) {
+                            changes.get(projectName).deletedSmithyFileUris().add(changedUri);
+                        }
+                    }
+                });
+            } else {
+                projectBuildFileMatchers.forEach((projectName, matcher) -> {
+                    if (matcher.matches(changedPath)) {
+                        changes.get(projectName).changedBuildFileUris().add(changedUri);
+                    }
+                });
+            }
+        }
+
+        return changes;
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/RequestBuilders.java
+++ b/src/test/java/software/amazon/smithy/lsp/RequestBuilders.java
@@ -74,10 +74,10 @@ public final class RequestBuilders {
     }
 
     public static final class DidChange {
-        public String uri;
-        public Integer version;
-        public Range range;
-        public String text;
+        private String uri;
+        private Integer version;
+        private Range range;
+        private String text;
 
         public DidChange next() {
             this.version += 1;
@@ -118,8 +118,8 @@ public final class RequestBuilders {
     }
 
     public static final class Initialize {
-        public List<WorkspaceFolder> workspaceFolders = new ArrayList<>();
-        public Object initializationOptions;
+        private final List<WorkspaceFolder> workspaceFolders = new ArrayList<>();
+        private Object initializationOptions;
 
         public Initialize workspaceFolder(String uri, String name) {
             this.workspaceFolders.add(new WorkspaceFolder(uri, name));
@@ -143,7 +143,7 @@ public final class RequestBuilders {
     }
 
     public static final class DidClose {
-        public String uri;
+        private String uri;
 
         public DidClose uri(String uri) {
             this.uri = uri;
@@ -156,10 +156,10 @@ public final class RequestBuilders {
     }
 
     public static final class DidOpen {
-        public String uri;
-        public String languageId = "smithy";
-        public int version = 1;
-        public String text;
+        private String uri;
+        private String languageId = "smithy";
+        private int version = 1;
+        private String text;
 
         public DidOpen uri(String uri) {
             this.uri = uri;
@@ -190,7 +190,7 @@ public final class RequestBuilders {
     }
 
     public static final class DidSave {
-        String uri;
+        private String uri;
 
         public DidSave uri(String uri) {
             this.uri = uri;
@@ -203,9 +203,9 @@ public final class RequestBuilders {
     }
 
     public static final class PositionRequest {
-        String uri;
-        int line;
-        int character;
+        private String uri;
+        private int line;
+        private int character;
 
         public PositionRequest uri(String uri) {
             this.uri = uri;
@@ -245,7 +245,7 @@ public final class RequestBuilders {
     }
 
     public static final class DidChangeWatchedFiles {
-        public final List<FileEvent> changes = new ArrayList<>();
+        private final List<FileEvent> changes = new ArrayList<>();
 
         public DidChangeWatchedFiles event(String uri, FileChangeType type) {
             this.changes.add(new FileEvent(uri, type));
@@ -258,8 +258,8 @@ public final class RequestBuilders {
     }
 
     public static final class DidChangeWorkspaceFolders {
-        final List<WorkspaceFolder> added = new ArrayList<>();
-        final List<WorkspaceFolder> removed = new ArrayList<>();
+        private final List<WorkspaceFolder> added = new ArrayList<>();
+        private final List<WorkspaceFolder> removed = new ArrayList<>();
 
         public DidChangeWorkspaceFolders added(String uri, String name) {
             this.added.add(new WorkspaceFolder(uri, name));

--- a/src/test/java/software/amazon/smithy/lsp/RequestBuilders.java
+++ b/src/test/java/software/amazon/smithy/lsp/RequestBuilders.java
@@ -17,6 +17,7 @@ import org.eclipse.lsp4j.CompletionTriggerKind;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
@@ -31,6 +32,7 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
 import software.amazon.smithy.utils.IoUtils;
 
 /**
@@ -65,6 +67,10 @@ public final class RequestBuilders {
 
     public static DidChangeWatchedFiles didChangeWatchedFiles() {
         return new DidChangeWatchedFiles();
+    }
+
+    public static DidChangeWorkspaceFolders didChangeWorkspaceFolders() {
+        return new DidChangeWorkspaceFolders();
     }
 
     public static final class DidChange {
@@ -248,6 +254,26 @@ public final class RequestBuilders {
 
         public DidChangeWatchedFilesParams build() {
             return new DidChangeWatchedFilesParams(changes);
+        }
+    }
+
+    public static final class DidChangeWorkspaceFolders {
+        final List<WorkspaceFolder> added = new ArrayList<>();
+        final List<WorkspaceFolder> removed = new ArrayList<>();
+
+        public DidChangeWorkspaceFolders added(String uri, String name) {
+            this.added.add(new WorkspaceFolder(uri, name));
+            return this;
+        }
+
+        public DidChangeWorkspaceFolders removed(String uri, String name) {
+            this.removed.add(new WorkspaceFolder(uri, name));
+            return this;
+        }
+
+        public DidChangeWorkspaceFoldersParams build() {
+            return new DidChangeWorkspaceFoldersParams(
+                    new WorkspaceFoldersChangeEvent(added, removed));
         }
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
@@ -1807,7 +1807,11 @@ public class SmithyLanguageServerTest {
 
         server.didChange(RequestBuilders.didChange()
                 .uri(fooUri)
-                .text("$version: \"2\"\nnamespace com.foo\nstructure Foo {}\n")
+                .text("""
+                        $version: "2"
+                        namespace com.foo
+                        structure Foo {}
+                        """)
                 .range(LspAdapter.origin())
                 .build());
 
@@ -1817,7 +1821,9 @@ public class SmithyLanguageServerTest {
 
         server.didChange(RequestBuilders.didChange()
                 .uri(fooUri)
-                .text("\nstructure Bar {}")
+                .text("""
+                        
+                        structure Bar {}""")
                 .range(LspAdapter.point(3, 0))
                 .build());
 
@@ -1826,9 +1832,9 @@ public class SmithyLanguageServerTest {
         Project projectFoo = server.getProjects().getProjectByName("foo");
         Project projectBar = server.getProjects().getProjectByName("bar");
 
-        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("model/main.smithy")));
-        assertThat(projectBar.smithyFiles(), hasKey(endsWith("model/main.smithy")));
-        assertThat(projectBar.smithyFiles(), hasKey(endsWith("model/other.smithy")));
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("other.smithy")));
 
         assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
         assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Bar")));
@@ -1913,8 +1919,8 @@ public class SmithyLanguageServerTest {
         Project projectFoo = server.getProjects().getProjectByName("foo");
         Project projectBar = server.getProjects().getProjectByName("bar");
 
-        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("model/main.smithy")));
-        assertThat(projectBar.smithyFiles(), hasKey(endsWith("model/main.smithy")));
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("main.smithy")));
         assertThat(projectBar.smithyFiles(), hasKey(endsWith("other.smithy")));
 
         assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));

--- a/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
@@ -1686,8 +1686,8 @@ public class SmithyLanguageServerTest {
 
         SmithyLanguageServer server = initFromWorkspaces(workspaceFoo, workspaceBar);
 
-        assertThat(server.getProjects().nonDetachedProjects(), hasKey("foo"));
-        assertThat(server.getProjects().nonDetachedProjects(), hasKey("bar"));
+        assertThat(server.getProjects().attachedProjects(), hasKey("foo"));
+        assertThat(server.getProjects().attachedProjects(), hasKey("bar"));
 
         assertThat(server.getProjects().getDocument(workspaceFoo.getUri("foo.smithy")), notNullValue());
         assertThat(server.getProjects().getDocument(workspaceBar.getUri("bar.smithy")), notNullValue());
@@ -1971,8 +1971,8 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().waitForAllTasks();
 
-        assertThat(server.getProjects().nonDetachedProjects(), hasKey("foo"));
-        assertThat(server.getProjects().nonDetachedProjects(), hasKey("bar"));
+        assertThat(server.getProjects().attachedProjects(), hasKey("foo"));
+        assertThat(server.getProjects().attachedProjects(), hasKey("bar"));
 
         assertThat(server.getProjects().getDocument(workspaceFoo.getUri("foo.smithy")), notNullValue());
         assertThat(server.getProjects().getDocument(workspaceBar.getUri("bar.smithy")), notNullValue());
@@ -2027,8 +2027,8 @@ public class SmithyLanguageServerTest {
                 .removed(workspaceBar.getRoot().toUri().toString(), "bar")
                 .build());
 
-        assertThat(server.getProjects().nonDetachedProjects(), hasKey("foo"));
-        assertThat(server.getProjects().nonDetachedProjects(), not(hasKey("bar")));
+        assertThat(server.getProjects().attachedProjects(), hasKey("foo"));
+        assertThat(server.getProjects().attachedProjects(), not(hasKey("bar")));
         assertThat(server.getProjects().detachedProjects(), hasKey(endsWith("bar.smithy")));
         assertThat(server.getProjects().isDetached(workspaceBar.getUri("bar.smithy")), is(true));
 

--- a/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.smithy.lsp;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -59,11 +60,11 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.MavenConfig;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.lsp.document.Document;
+import software.amazon.smithy.lsp.project.Project;
 import software.amazon.smithy.lsp.protocol.LspAdapter;
 import software.amazon.smithy.lsp.protocol.RangeBuilder;
 import software.amazon.smithy.model.node.ArrayNode;
@@ -176,7 +177,7 @@ public class SmithyLanguageServerTest {
 
         assertThat(completions, containsInAnyOrder(hasLabel("Bar")));
 
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
         // TODO: The server puts the 'use' on the wrong line
         assertThat(completions.get(0).getAdditionalTextEdits(), containsInAnyOrder(makesEditedDocument(document, safeString("$version: \"2\"\n" +
                                                                                                       "namespace com.foo\n" +
@@ -228,7 +229,7 @@ public class SmithyLanguageServerTest {
         List<? extends Location> traitLocations = server.definition(traitParams).get().getLeft();
         List<? extends Location> wsLocations = server.definition(wsParams).get().getLeft();
 
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
         assertNotNull(document);
 
         assertThat(memberTargetLocations, hasSize(1));
@@ -376,9 +377,9 @@ public class SmithyLanguageServerTest {
         TextDocumentIdentifier id = new TextDocumentIdentifier(uri);
         DocumentFormattingParams params = new DocumentFormattingParams(id, new FormattingOptions());
         List<? extends TextEdit> edits = server.formatting(params).get();
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
 
-        assertThat(edits, (Matcher) containsInAnyOrder(makesEditedDocument(document, safeString("$version: \"2\"\n" +
+        assertThat(edits, containsInAnyOrder(makesEditedDocument(document, safeString("$version: \"2\"\n" +
                                                                 "\n" +
                                                                 "namespace com.foo\n" +
                                                                 "\n" +
@@ -434,16 +435,16 @@ public class SmithyLanguageServerTest {
         server.getLifecycleManager().waitForAllTasks();
 
         // mostly so you can see what it looks like
-        assertThat(server.getProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
-                                                                            "\n" +
-                                                                            "namespace com.foo\n" +
-                                                                            "\n" +
-                                                                            "structure GetFooInput {\n" +
-                                                                            "}\n" +
-                                                                            "\n" +
-                                                                            "operation GetFoo {\n" +
-                                                                            "    input: G\n" +
-                                                                            "}\n")));
+        assertThat(server.getFirstProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
+                                                                                            "\n" +
+                                                                                            "namespace com.foo\n" +
+                                                                                            "\n" +
+                                                                                            "structure GetFooInput {\n" +
+                                                                                            "}\n" +
+                                                                                            "\n" +
+                                                                                            "operation GetFoo {\n" +
+                                                                                            "    input: G\n" +
+                                                                                            "}\n")));
 
         // input: G
         CompletionParams completionParams = new RequestBuilders.PositionRequest()
@@ -471,7 +472,7 @@ public class SmithyLanguageServerTest {
                 .text(model)
                 .build();
         server.didOpen(openParams);
-        assertThat(server.getProject().modelResult().getValidationEvents(), empty());
+        assertThat(server.getFirstProject().modelResult().getValidationEvents(), empty());
 
         DidChangeTextDocumentParams didChangeParams = new RequestBuilders.DidChange()
                 .uri(uri)
@@ -482,13 +483,13 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().getTask(uri).get();
 
-        assertThat(server.getProject().modelResult().getValidationEvents(),
+        assertThat(server.getFirstProject().modelResult().getValidationEvents(),
                 containsInAnyOrder(eventWithMessage(containsString("Error creating trait"))));
 
         DidSaveTextDocumentParams didSaveParams = new RequestBuilders.DidSave().uri(uri).build();
         server.didSave(didSaveParams);
 
-        assertThat(server.getProject().modelResult().getValidationEvents(),
+        assertThat(server.getFirstProject().modelResult().getValidationEvents(),
                 containsInAnyOrder(eventWithMessage(containsString("Error creating trait"))));
     }
 
@@ -539,16 +540,16 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().getTask(uri).get();
 
-        assertThat(server.getProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
-                                                                            "namespace com.foo\n" +
-                                                                            "\n" +
-                                                                            "structure Foo {\n" +
-                                                                            "    bar: Bar\n" +
-                                                                            "}\n" +
-                                                                            "\n" +
-                                                                            "string Baz\n" +
-                                                                            "\n" +
-                                                                            "string Bar\n")));
+        assertThat(server.getFirstProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
+                                                                                            "namespace com.foo\n" +
+                                                                                            "\n" +
+                                                                                            "structure Foo {\n" +
+                                                                                            "    bar: Bar\n" +
+                                                                                            "}\n" +
+                                                                                            "\n" +
+                                                                                            "string Baz\n" +
+                                                                                            "\n" +
+                                                                                            "string Bar\n")));
 
         Location afterChanges = server.definition(definitionParams).get().getLeft().get(0);
         assertThat(afterChanges.getUri(), equalTo(uri));
@@ -649,13 +650,13 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().getTask(uri).get();
 
-        assertThat(server.getProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
-                                                                            "namespace com.foo\n" +
-                                                                            "\n" +
-                                                                            "@mixin\n" +
-                                                                            "structure Foo {}\n" +
-                                                                            "\n" +
-                                                                            "structure Bar with [F]")));
+        assertThat(server.getFirstProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
+                                                                                            "namespace com.foo\n" +
+                                                                                            "\n" +
+                                                                                            "@mixin\n" +
+                                                                                            "structure Foo {}\n" +
+                                                                                            "\n" +
+                                                                                            "structure Bar with [F]")));
 
         Position currentPosition = range.build().getStart();
         CompletionParams completionParams = new RequestBuilders.PositionRequest()
@@ -663,7 +664,7 @@ public class SmithyLanguageServerTest {
                 .position(range.shiftRight().build().getStart())
                 .buildCompletion();
 
-        assertThat(server.getProject().getDocument(uri).copyToken(currentPosition), equalTo("F"));
+        assertThat(server.getFirstProject().getDocument(uri).copyToken(currentPosition), equalTo("F"));
 
         List<CompletionItem> completions = server.completion(completionParams).get().getLeft();
 
@@ -705,13 +706,13 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().getTask(uri).get();
 
-        assertThat(server.getProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
-                                                                            "namespace com.foo\n" +
-                                                                            "\n" +
-                                                                            "@mixin\n" +
-                                                                            "structure Foo {}\n" +
-                                                                            "\n" +
-                                                                            "structure Bar with [F] {}\n")));
+        assertThat(server.getFirstProject().getDocument(uri).copyText(), equalTo(safeString("$version: \"2\"\n" +
+                                                                                            "namespace com.foo\n" +
+                                                                                            "\n" +
+                                                                                            "@mixin\n" +
+                                                                                            "structure Foo {}\n" +
+                                                                                            "\n" +
+                                                                                            "structure Bar with [F] {}\n")));
 
         Position currentPosition = range.build().getStart();
         CompletionParams completionParams = new RequestBuilders.PositionRequest()
@@ -719,7 +720,7 @@ public class SmithyLanguageServerTest {
                 .position(range.shiftRight().build().getStart())
                 .buildCompletion();
 
-        assertThat(server.getProject().getDocument(uri).copyToken(currentPosition), equalTo("F"));
+        assertThat(server.getFirstProject().getDocument(uri).copyToken(currentPosition), equalTo("F"));
 
         List<CompletionItem> completions = server.completion(completionParams).get().getLeft();
 
@@ -744,7 +745,7 @@ public class SmithyLanguageServerTest {
         Diagnostic diagnostic = diagnostics.get(0);
         assertThat(diagnostic.getMessage(), startsWith("Target.UnresolvedShape"));
 
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
         assertThat(diagnostic.getRange(), hasText(document, equalTo("Bar")));
     }
 
@@ -772,7 +773,7 @@ public class SmithyLanguageServerTest {
         Diagnostic diagnostic = diagnostics.get(0);
         assertThat(diagnostic.getMessage(), startsWith("Model.UnresolvedTrait"));
 
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
         assertThat(diagnostic.getRange(), hasText(document, equalTo("@bar")));
     }
 
@@ -849,7 +850,7 @@ public class SmithyLanguageServerTest {
 
         String preludeUri = preludeLocation.getUri();
         assertThat(preludeUri, startsWith("smithyjar"));
-        Logger.getLogger(getClass().getName()).severe("DOCUMENT LINES: " + server.getProject().getDocument(preludeUri).fullRange());
+        Logger.getLogger(getClass().getName()).severe("DOCUMENT LINES: " + server.getFirstProject().getDocument(preludeUri).fullRange());
 
         Hover appliedTraitInPreludeHover = server.hover(RequestBuilders.positionRequest()
                 .uri(preludeUri)
@@ -894,9 +895,9 @@ public class SmithyLanguageServerTest {
 
         assertThat(server.getLifecycleManager().isManaged(uri), is(true));
         assertThat(server.getProjects().isDetached(uri), is(false));
-        assertThat(server.getProjects().mainProject().getSmithyFile(uri), notNullValue());
-        assertThat(server.getProjects().mainProject().getDocument(uri), notNullValue());
-        assertThat(server.getProjects().mainProject().getDocument(uri).copyText(), equalTo("$"));
+        assertThat(server.getFirstProject().getSmithyFile(uri), notNullValue());
+        assertThat(server.getProjects().getDocument(uri), notNullValue());
+        assertThat(server.getProjects().getDocument(uri).copyText(), equalTo("$"));
     }
 
     @Test
@@ -1027,7 +1028,7 @@ public class SmithyLanguageServerTest {
                            + "string Foo\n");
         TestWorkspace workspace = TestWorkspace.builder()
                 .withSourceDir(TestWorkspace.dir()
-                        .path("./smithy")
+                        .withPath("./smithy")
                         .withSourceFile("main.smithy", modelText))
                 .withConfig(config)
                 .build();
@@ -1066,7 +1067,7 @@ public class SmithyLanguageServerTest {
         TestWorkspace workspace = TestWorkspace.multipleModels(modelText1, modelText2);
         SmithyLanguageServer server = initFromWorkspace(workspace);
 
-        Map<String, Node> metadataBefore = server.getProject().modelResult().unwrap().getMetadata();
+        Map<String, Node> metadataBefore = server.getFirstProject().modelResult().unwrap().getMetadata();
         assertThat(metadataBefore, hasKey("foo"));
         assertThat(metadataBefore, hasKey("bar"));
         assertThat(metadataBefore.get("foo"), instanceOf(ArrayNode.class));
@@ -1088,7 +1089,7 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().getTask(uri).get();
 
-        Map<String, Node> metadataAfter = server.getProject().modelResult().unwrap().getMetadata();
+        Map<String, Node> metadataAfter = server.getFirstProject().modelResult().unwrap().getMetadata();
         assertThat(metadataAfter, hasKey("foo"));
         assertThat(metadataAfter, hasKey("bar"));
         assertThat(metadataAfter.get("foo"), instanceOf(ArrayNode.class));
@@ -1102,7 +1103,7 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().getTask(uri).get();
 
-        Map<String, Node> metadataAfter2 = server.getProject().modelResult().unwrap().getMetadata();
+        Map<String, Node> metadataAfter2 = server.getFirstProject().modelResult().unwrap().getMetadata();
         assertThat(metadataAfter2, hasKey("foo"));
         assertThat(metadataAfter2, hasKey("bar"));
         assertThat(metadataAfter2.get("foo"), instanceOf(ArrayNode.class));
@@ -1130,7 +1131,7 @@ public class SmithyLanguageServerTest {
         TestWorkspace workspace = TestWorkspace.multipleModels(modelText1, modelText2);
         SmithyLanguageServer server = initFromWorkspace(workspace);
 
-        Map<String, Node> metadataBefore = server.getProject().modelResult().unwrap().getMetadata();
+        Map<String, Node> metadataBefore = server.getFirstProject().modelResult().unwrap().getMetadata();
         assertThat(metadataBefore, hasKey("foo"));
         assertThat(metadataBefore, hasKey("bar"));
         assertThat(metadataBefore.get("foo"), instanceOf(ArrayNode.class));
@@ -1145,7 +1146,7 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().waitForAllTasks();
 
-        Map<String, Node> metadataAfter = server.getProject().modelResult().unwrap().getMetadata();
+        Map<String, Node> metadataAfter = server.getFirstProject().modelResult().unwrap().getMetadata();
         assertThat(metadataAfter, hasKey("foo"));
         assertThat(metadataAfter, hasKey("bar"));
         assertThat(metadataAfter.get("foo"), instanceOf(ArrayNode.class));
@@ -1202,9 +1203,9 @@ public class SmithyLanguageServerTest {
 
         assertThat(server.getLifecycleManager().managedDocuments(), hasItem(uri));
         assertThat(server.getProjects().isDetached(uri), is(false));
-        assertThat(server.getProject().getSmithyFile(uri), notNullValue());
-        assertThat(server.getProject().modelResult().unwrap(), hasShapeWithId("com.foo#Foo"));
-        assertThat(server.getProject().modelResult().unwrap(), hasShapeWithId("com.foo#Bar"));
+        assertThat(server.getFirstProject().getSmithyFile(uri), notNullValue());
+        assertThat(server.getFirstProject().modelResult().unwrap(), hasShapeWithId("com.foo#Foo"));
+        assertThat(server.getFirstProject().modelResult().unwrap(), hasShapeWithId("com.foo#Bar"));
     }
 
     @Test
@@ -1355,10 +1356,10 @@ public class SmithyLanguageServerTest {
 
         String uri = workspace.getUri("model-0.smithy");
 
-        assertThat(server.getProject().getSmithyFile(uri), notNullValue());
-        assertThat(server.getProject().modelResult().isBroken(), is(true));
-        assertThat(server.getProject().modelResult().getResult().isPresent(), is(true));
-        assertThat(server.getProject().modelResult().getResult().get(), hasShapeWithId("com.foo#Foo"));
+        assertThat(server.getFirstProject().getSmithyFile(uri), notNullValue());
+        assertThat(server.getFirstProject().modelResult().isBroken(), is(true));
+        assertThat(server.getFirstProject().modelResult().getResult().isPresent(), is(true));
+        assertThat(server.getFirstProject().modelResult().getResult().get(), hasShapeWithId("com.foo#Foo"));
     }
 
     @Test
@@ -1453,8 +1454,8 @@ public class SmithyLanguageServerTest {
 
         assertThat(server.getProjects().isDetached(uri), is(false));
         assertThat(server.getProjects().detachedProjects().keySet(), empty());
-        assertThat(server.getProject().getSmithyFile(uri), notNullValue());
-        assertThat(server.getProject().modelResult(), hasValue(hasShapeWithId("com.foo#Foo")));
+        assertThat(server.getFirstProject().getSmithyFile(uri), notNullValue());
+        assertThat(server.getFirstProject().modelResult(), hasValue(hasShapeWithId("com.foo#Foo")));
     }
 
     @Test
@@ -1483,8 +1484,8 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().waitForAllTasks();
 
-        assertThat(server.getProject().modelResult(), hasValue(hasShapeWithId("com.foo#Bar")));
-        Shape foo = server.getProject().modelResult().getResult().get().expectShape(ShapeId.from("com.foo#Foo"));
+        assertThat(server.getFirstProject().modelResult(), hasValue(hasShapeWithId("com.foo#Bar")));
+        Shape foo = server.getFirstProject().modelResult().getResult().get().expectShape(ShapeId.from("com.foo#Foo"));
         assertThat(foo.getIntroducedTraits().keySet(), containsInAnyOrder(LengthTrait.ID));
         assertThat(foo.expectTrait(LengthTrait.class).getMin(), anOptionalOf(equalTo(2L)));
 
@@ -1502,9 +1503,9 @@ public class SmithyLanguageServerTest {
 
         server.getLifecycleManager().waitForAllTasks();
 
-        assertThat(server.getProject().modelResult(), hasValue(hasShapeWithId("com.foo#Bar")));
-        assertThat(server.getProject().modelResult(), hasValue(hasShapeWithId("com.foo#Another")));
-        foo = server.getProject().modelResult().getResult().get().expectShape(ShapeId.from("com.foo#Foo"));
+        assertThat(server.getFirstProject().modelResult(), hasValue(hasShapeWithId("com.foo#Bar")));
+        assertThat(server.getFirstProject().modelResult(), hasValue(hasShapeWithId("com.foo#Another")));
+        foo = server.getFirstProject().modelResult().getResult().get().expectShape(ShapeId.from("com.foo#Foo"));
         assertThat(foo.getIntroducedTraits().keySet(), containsInAnyOrder(LengthTrait.ID));
         assertThat(foo.expectTrait(LengthTrait.class).getMin(), anOptionalOf(equalTo(2L)));
     }
@@ -1661,6 +1662,382 @@ public class SmithyLanguageServerTest {
         assertThat(completions.get(0).getAdditionalTextEdits(), nullValue());
     }
 
+    @Test
+    public void loadsMultipleRoots() {
+        TestWorkspace workspaceFoo = TestWorkspace.builder()
+                .withName("foo")
+                .withPath("foo")
+                .withSourceFile("foo.smithy", """
+                        $version: "2"
+                        namespace com.foo
+                        structure Foo {}
+                        """)
+                .build();
+
+        TestWorkspace workspaceBar = TestWorkspace.builder()
+                .withName("bar")
+                .withPath("bar")
+                .withSourceFile("bar.smithy", """
+                        $version: "2"
+                        namespace com.bar
+                        structure Bar {}
+                        """)
+                .build();
+
+        SmithyLanguageServer server = initFromWorkspaces(workspaceFoo, workspaceBar);
+
+        assertThat(server.getProjects().nonDetachedProjects(), hasKey("foo"));
+        assertThat(server.getProjects().nonDetachedProjects(), hasKey("bar"));
+
+        assertThat(server.getProjects().getDocument(workspaceFoo.getUri("foo.smithy")), notNullValue());
+        assertThat(server.getProjects().getDocument(workspaceBar.getUri("bar.smithy")), notNullValue());
+
+        Project projectFoo = server.getProjects().getProjectByName("foo");
+        Project projectBar = server.getProjects().getProjectByName("bar");
+
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("foo.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("bar.smithy")));
+
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar")));
+    }
+
+    @Test
+    public void multiRootLifecycleManagement() throws Exception {
+        TestWorkspace workspaceFoo = TestWorkspace.builder()
+                .withName("foo")
+                .withPath("foo")
+                .withSourceFile("foo.smithy", """
+                        $version: "2"
+                        namespace com.foo
+                        structure Foo {}
+                        """)
+                .build();
+
+        TestWorkspace workspaceBar = TestWorkspace.builder()
+                .withName("bar")
+                .withPath("bar")
+                .withSourceFile("bar.smithy", """
+                        $version: "2"
+                        namespace com.bar
+                        structure Bar {}
+                        """)
+                .build();
+
+        SmithyLanguageServer server = initFromWorkspaces(workspaceFoo, workspaceBar);
+
+        String fooUri = workspaceFoo.getUri("foo.smithy");
+        String barUri = workspaceBar.getUri("bar.smithy");
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(fooUri)
+                .build());
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(barUri)
+                .build());
+
+        server.didChange(RequestBuilders.didChange()
+                .uri(fooUri)
+                .text("\nstructure Bar {}")
+                .range(LspAdapter.point(server.getProjects().getDocument(fooUri).end()))
+                .build());
+        server.didChange(RequestBuilders.didChange()
+                .uri(barUri)
+                .text("\nstructure Foo {}")
+                .range(LspAdapter.point(server.getProjects().getDocument(barUri).end()))
+                .build());
+
+        server.didSave(RequestBuilders.didSave()
+                .uri(fooUri)
+                .build());
+        server.didSave(RequestBuilders.didSave()
+                .uri(barUri)
+                .build());
+
+        server.getLifecycleManager().waitForAllTasks();
+
+        Project projectFoo = server.getProjects().getProjectByName("foo");
+        Project projectBar = server.getProjects().getProjectByName("bar");
+
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Bar")));
+
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Foo")));
+    }
+
+    @Test
+    public void multiRootAddingWatchedFile() throws Exception {
+        TestWorkspace workspaceFoo = TestWorkspace.builder()
+                .withName("foo")
+                .withPath("foo")
+                .withSourceDir(new TestWorkspace.Dir()
+                        .withPath("model")
+                        .withSourceFile("main.smithy", ""))
+                .build();
+        TestWorkspace workspaceBar = TestWorkspace.builder()
+                .withName("bar")
+                .withPath("bar")
+                .withSourceDir(new TestWorkspace.Dir()
+                        .withPath("model")
+                        .withSourceFile("main.smithy", ""))
+                .build();
+
+        SmithyLanguageServer server = initFromWorkspaces(workspaceFoo, workspaceBar);
+
+        String fooUri = workspaceFoo.getUri("model/main.smithy");
+        String barUri = workspaceBar.getUri("model/main.smithy");
+
+        String newFilename = "model/other.smithy";
+        String newText = """
+                $version: "2"
+                namespace com.bar
+                structure Bar {}
+                """;
+        workspaceBar.addModel(newFilename, newText);
+
+        String newUri = workspaceBar.getUri(newFilename);
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(fooUri)
+                .build());
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(barUri)
+                .build());
+
+        server.didChange(RequestBuilders.didChange()
+                .uri(fooUri)
+                .text("$version: \"2\"\nnamespace com.foo\nstructure Foo {}\n")
+                .range(LspAdapter.origin())
+                .build());
+
+        server.didChangeWatchedFiles(RequestBuilders.didChangeWatchedFiles()
+                .event(newUri, FileChangeType.Created)
+                .build());
+
+        server.didChange(RequestBuilders.didChange()
+                .uri(fooUri)
+                .text("\nstructure Bar {}")
+                .range(LspAdapter.point(3, 0))
+                .build());
+
+        server.getLifecycleManager().waitForAllTasks();
+
+        Project projectFoo = server.getProjects().getProjectByName("foo");
+        Project projectBar = server.getProjects().getProjectByName("bar");
+
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("model/main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("model/main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("model/other.smithy")));
+
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Bar")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar")));
+    }
+
+    @Test
+    public void multiRootChangingBuildFile() throws Exception {
+        TestWorkspace workspaceFoo = TestWorkspace.builder()
+                .withName("foo")
+                .withPath("foo")
+                .withSourceDir(new TestWorkspace.Dir()
+                        .withPath("model")
+                        .withSourceFile("main.smithy", ""))
+                .build();
+        TestWorkspace workspaceBar = TestWorkspace.builder()
+                .withName("bar")
+                .withPath("bar")
+                .withSourceDir(new TestWorkspace.Dir()
+                        .withPath("model")
+                        .withSourceFile("main.smithy", ""))
+                .build();
+
+        SmithyLanguageServer server = initFromWorkspaces(workspaceFoo, workspaceBar);
+
+        String newFilename = "other.smithy";
+        String newText = """
+                $version: "2"
+                namespace com.other
+                structure Other {}
+                """;
+        workspaceBar.addModel(newFilename, newText);
+        String newUri = workspaceBar.getUri(newFilename);
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(newUri)
+                .text(newText)
+                .build());
+
+        List<String> updatedSources = new ArrayList<>(workspaceBar.getConfig().getSources());
+        updatedSources.add(newFilename);
+        workspaceBar.updateConfig(workspaceBar.getConfig().toBuilder()
+                .sources(updatedSources)
+                .build());
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(workspaceFoo.getUri("model/main.smithy"))
+                .build());
+        server.didChange(RequestBuilders.didChange()
+                .uri(workspaceFoo.getUri("model/main.smithy"))
+                .text("""
+                        $version: "2"
+                        namespace com.foo
+                        structure Foo {}
+                        """)
+                .range(LspAdapter.origin())
+                .build());
+
+        server.didChangeWatchedFiles(RequestBuilders.didChangeWatchedFiles()
+                .event(workspaceBar.getUri("smithy-build.json"), FileChangeType.Changed)
+                .build());
+
+        server.didChange(RequestBuilders.didChange()
+                .uri(workspaceBar.getUri("model/main.smithy"))
+                .text("""
+                        $version: "2"
+                        namespace com.bar
+                        structure Bar {
+                            other: com.other#Other
+                        }
+                        """)
+                .range(LspAdapter.origin())
+                .build());
+
+        server.getLifecycleManager().waitForAllTasks();
+
+        assertThat(server.getProjects().detachedProjects(), anEmptyMap());
+        assertThat(server.getProjects().getProject(newUri), notNullValue());
+        assertThat(server.getProjects().getProject(workspaceBar.getUri("model/main.smithy")), notNullValue());
+        assertThat(server.getProjects().getProject(workspaceFoo.getUri("model/main.smithy")), notNullValue());
+
+        Project projectFoo = server.getProjects().getProjectByName("foo");
+        Project projectBar = server.getProjects().getProjectByName("bar");
+
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("model/main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("model/main.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("other.smithy")));
+
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar$other")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.other#Other")));
+    }
+
+    @Test
+    public void addingWorkspaceFolder() throws Exception {
+        String fooModel = """
+                        $version: "2"
+                        namespace com.foo
+                        structure Foo {}
+                        """;
+        TestWorkspace workspaceFoo = TestWorkspace.builder()
+                .withName("foo")
+                .withPath("foo")
+                .withSourceFile("foo.smithy", fooModel)
+                .build();
+
+        SmithyLanguageServer server = initFromWorkspace(workspaceFoo);
+
+        String barModel = """
+                        $version: "2"
+                        namespace com.bar
+                        structure Bar {}
+                        """;
+        TestWorkspace workspaceBar = TestWorkspace.builder()
+                .withName("bar")
+                .withPath("bar")
+                .withSourceFile("bar.smithy", barModel)
+                .build();
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(workspaceFoo.getUri("foo.smithy"))
+                .text(fooModel)
+                .build());
+
+        server.didChangeWorkspaceFolders(RequestBuilders.didChangeWorkspaceFolders()
+                .added(workspaceBar.getRoot().toUri().toString(), "bar")
+                .build());
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(workspaceBar.getUri("bar.smithy"))
+                .text(barModel)
+                .build());
+
+        server.getLifecycleManager().waitForAllTasks();
+
+        assertThat(server.getProjects().nonDetachedProjects(), hasKey("foo"));
+        assertThat(server.getProjects().nonDetachedProjects(), hasKey("bar"));
+
+        assertThat(server.getProjects().getDocument(workspaceFoo.getUri("foo.smithy")), notNullValue());
+        assertThat(server.getProjects().getDocument(workspaceBar.getUri("bar.smithy")), notNullValue());
+
+        Project projectFoo = server.getProjects().getProjectByName("foo");
+        Project projectBar = server.getProjects().getProjectByName("bar");
+
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("foo.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("bar.smithy")));
+
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar")));
+    }
+
+    @Test
+    public void removingWorkspaceFolder() {
+        String fooModel = """
+                        $version: "2"
+                        namespace com.foo
+                        structure Foo {}
+                        """;
+        TestWorkspace workspaceFoo = TestWorkspace.builder()
+                .withName("foo")
+                .withPath("foo")
+                .withSourceFile("foo.smithy", fooModel)
+                .build();
+
+        String barModel = """
+                        $version: "2"
+                        namespace com.bar
+                        structure Bar {}
+                        """;
+        TestWorkspace workspaceBar = TestWorkspace.builder()
+                .withName("bar")
+                .withPath("bar")
+                .withSourceFile("bar.smithy", barModel)
+                .build();
+
+        SmithyLanguageServer server = initFromWorkspaces(workspaceFoo, workspaceBar);
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(workspaceFoo.getUri("foo.smithy"))
+                .text(fooModel)
+                .build());
+
+        server.didOpen(RequestBuilders.didOpen()
+                .uri(workspaceBar.getUri("bar.smithy"))
+                .text(barModel)
+                .build());
+
+        server.didChangeWorkspaceFolders(RequestBuilders.didChangeWorkspaceFolders()
+                .removed(workspaceBar.getRoot().toUri().toString(), "bar")
+                .build());
+
+        assertThat(server.getProjects().nonDetachedProjects(), hasKey("foo"));
+        assertThat(server.getProjects().nonDetachedProjects(), not(hasKey("bar")));
+        assertThat(server.getProjects().detachedProjects(), hasKey(endsWith("bar.smithy")));
+        assertThat(server.getProjects().isDetached(workspaceBar.getUri("bar.smithy")), is(true));
+
+        assertThat(server.getProjects().getDocument(workspaceFoo.getUri("foo.smithy")), notNullValue());
+        assertThat(server.getProjects().getDocument(workspaceBar.getUri("bar.smithy")), notNullValue());
+
+        Project projectFoo = server.getProjects().getProjectByName("foo");
+        Project projectBar = server.getProjects().getProject(workspaceBar.getUri("bar.smithy"));
+
+        assertThat(projectFoo.smithyFiles(), hasKey(endsWith("foo.smithy")));
+        assertThat(projectBar.smithyFiles(), hasKey(endsWith("bar.smithy")));
+
+        assertThat(projectFoo.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.foo#Foo")));
+        assertThat(projectBar.modelResult(), SmithyMatchers.hasValue(SmithyMatchers.hasShapeWithId("com.bar#Bar")));
+    }
     public static SmithyLanguageServer initFromWorkspace(TestWorkspace workspace) {
         return initFromWorkspace(workspace, new StubClient());
     }
@@ -1671,7 +2048,7 @@ public class SmithyLanguageServerTest {
             server.connect(client);
 
             server.initialize(RequestBuilders.initialize()
-                    .workspaceFolder(workspace.getRoot().toUri().toString(), "test")
+                    .workspaceFolder(workspace.getRoot().toUri().toString(), workspace.getName())
                     .build())
                     .get();
 
@@ -1679,6 +2056,25 @@ public class SmithyLanguageServerTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public static SmithyLanguageServer initFromWorkspaces(TestWorkspace... workspaces) {
+        LanguageClient client = new StubClient();
+        SmithyLanguageServer server = new SmithyLanguageServer();
+        server.connect(client);
+
+        RequestBuilders.Initialize initialize = RequestBuilders.initialize();
+        for (TestWorkspace workspace : workspaces) {
+            initialize.workspaceFolder(workspace.getRoot().toUri().toString(), workspace.getName());
+        }
+
+        try {
+            server.initialize(initialize.build()).get();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        return server;
     }
 
     public static SmithyLanguageServer initFromRoot(Path root) {

--- a/src/test/java/software/amazon/smithy/lsp/SmithyVersionRefactoringTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyVersionRefactoringTest.java
@@ -86,7 +86,7 @@ public class SmithyVersionRefactoringTest {
         List<TextEdit> edits = action.getEdit().getChanges().get(uri);
         assertThat(edits, hasSize(1));
         TextEdit edit = edits.get(0);
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
         document.applyEdit(edit.getRange(), edit.getNewText());
         assertThat(document.copyText(), equalTo("$version: \"1\"\n" +
                                                 "\n" +
@@ -135,7 +135,7 @@ public class SmithyVersionRefactoringTest {
         List<TextEdit> edits = action.getEdit().getChanges().get(uri);
         assertThat(edits, hasSize(1));
         TextEdit edit = edits.get(0);
-        Document document = server.getProject().getDocument(uri);
+        Document document = server.getFirstProject().getDocument(uri);
         document.applyEdit(edit.getRange(), edit.getNewText());
         assertThat(document.copyText(), equalTo("$version: \"2\"\n" +
                                                 "namespace com.foo\n" +

--- a/src/test/java/software/amazon/smithy/lsp/StubClient.java
+++ b/src/test/java/software/amazon/smithy/lsp/StubClient.java
@@ -5,10 +5,12 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.ProgressParams;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
 import org.eclipse.lsp4j.services.LanguageClient;
 
 public final class StubClient implements LanguageClient {
@@ -63,4 +65,12 @@ public final class StubClient implements LanguageClient {
     public CompletableFuture<Void> unregisterCapability(UnregistrationParams params) {
         return CompletableFuture.completedFuture(null);
     }
+
+    @Override
+    public CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams params) {
+        return CompletableFuture.completedFuture(null);
+    }
+
+    @Override
+    public void notifyProgress(ProgressParams params) {}
 }

--- a/src/test/java/software/amazon/smithy/lsp/TestWorkspace.java
+++ b/src/test/java/software/amazon/smithy/lsp/TestWorkspace.java
@@ -25,10 +25,12 @@ public final class TestWorkspace {
     private static final NodeMapper MAPPER = new NodeMapper();
     private final Path root;
     private SmithyBuildConfig config;
+    private final String name;
 
-    private TestWorkspace(Path root, SmithyBuildConfig config) {
+    private TestWorkspace(Path root, SmithyBuildConfig config, String name) {
         this.root = root;
         this.config = config;
+        this.name = name;
     }
 
     /**
@@ -40,6 +42,10 @@ public final class TestWorkspace {
 
     public SmithyBuildConfig getConfig() {
         return config;
+    }
+
+    public String getName() {
+        return name;
     }
 
     /**
@@ -99,7 +105,7 @@ public final class TestWorkspace {
      */
     public static TestWorkspace emptyWithDirSource() {
         return builder()
-                .withSourceDir(new Dir().path("model"))
+                .withSourceDir(new Dir().withPath("model"))
                 .build();
     }
 
@@ -131,7 +137,7 @@ public final class TestWorkspace {
         List<Dir> sourceDirs = new ArrayList<>();
         List<Dir> importDirs = new ArrayList<>();
 
-        public Dir path(String path) {
+        public Dir withPath(String path) {
             this.path = path;
             return this;
         }
@@ -179,7 +185,15 @@ public final class TestWorkspace {
 
     public static final class Builder extends Dir {
         private SmithyBuildConfig config = null;
+        private String name = "";
+
         private Builder() {}
+
+        @Override
+        public Builder withPath(String path) {
+            this.path = path;
+            return this;
+        }
 
         @Override
         public Builder withSourceFile(String filename, String model) {
@@ -210,6 +224,11 @@ public final class TestWorkspace {
             return this;
         }
 
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
         public TestWorkspace build() {
             try {
                 if (path == null) {
@@ -237,7 +256,7 @@ public final class TestWorkspace {
 
                 writeModels(root);
 
-                return new TestWorkspace(root, config);
+                return new TestWorkspace(root, config, name);
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/test/java/software/amazon/smithy/lsp/UtilMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/UtilMatchers.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.lsp;
 
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 import java.util.Optional;
 import org.hamcrest.CustomTypeSafeMatcher;
 import org.hamcrest.Description;
@@ -30,6 +32,24 @@ public final class UtilMatchers {
                 } else {
                     matcher.describeMismatch(item.get(), description);
                 }
+            }
+        };
+    }
+
+    public static Matcher<PathMatcher> canMatchPath(Path path) {
+        // PathMatcher implementations don't seem to have a nice toString, so this Matcher
+        // doesn't print out the PathMatcher that couldn't match, but we could wrap the
+        // system default PathMatcher in one that stores the original pattern, if this
+        // Matcher becomes too hard to diagnose failures for.
+        return new CustomTypeSafeMatcher<PathMatcher>("A matcher that matches " + path) {
+            @Override
+            protected boolean matchesSafely(PathMatcher item) {
+                return item.matches(path);
+            }
+
+            @Override
+            protected void describeMismatchSafely(PathMatcher item, Description mismatchDescription) {
+                mismatchDescription.appendText("did not match");
             }
         };
     }

--- a/src/test/java/software/amazon/smithy/lsp/handler/FileWatcherRegistrationHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/handler/FileWatcherRegistrationHandlerTest.java
@@ -6,17 +6,18 @@
 package software.amazon.smithy.lsp.handler;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.hasItem;
 
+import java.nio.file.FileSystems;
+import java.nio.file.PathMatcher;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
 import org.eclipse.lsp4j.Registration;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.lsp.TestWorkspace;
+import software.amazon.smithy.lsp.UtilMatchers;
 import software.amazon.smithy.lsp.project.Project;
 import software.amazon.smithy.lsp.project.ProjectLoader;
 import software.amazon.smithy.lsp.project.ProjectManager;
@@ -44,17 +45,21 @@ public class FileWatcherRegistrationHandlerTest {
                 .build();
 
         Project project = ProjectLoader.load(workspace.getRoot(), new ProjectManager(), new HashSet<>()).unwrap();
-        List<String> watcherPatterns = FileWatcherRegistrationHandler.getSmithyFileWatcherRegistrations(List.of(project))
+        List<PathMatcher> matchers = FileWatcherRegistrationHandler.getSmithyFileWatcherRegistrations(List.of(project))
                 .stream()
                 .map(Registration::getRegisterOptions)
                 .map(o -> (DidChangeWatchedFilesRegistrationOptions) o)
                 .flatMap(options -> options.getWatchers().stream())
                 .map(watcher -> watcher.getGlobPattern().getLeft())
-                .collect(Collectors.toList());
+                // The watcher glob patterns will look different between windows/unix, so turning
+                // them into path matchers lets us do platform-agnostic assertions.
+                .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
+                .toList();
 
-        assertThat(watcherPatterns, containsInAnyOrder(
-                endsWith("foo/**.{smithy,json}"),
-                endsWith("other/**.{smithy,json}"),
-                endsWith("abc.smithy")));
+        assertThat(matchers, hasItem(UtilMatchers.canMatchPath(workspace.getRoot().resolve("foo/abc.smithy"))));
+        assertThat(matchers, hasItem(UtilMatchers.canMatchPath(workspace.getRoot().resolve("foo/foo/abc/def.smithy"))));
+        assertThat(matchers, hasItem(UtilMatchers.canMatchPath(workspace.getRoot().resolve("other/abc.smithy"))));
+        assertThat(matchers, hasItem(UtilMatchers.canMatchPath(workspace.getRoot().resolve("other/foo/abc.smithy"))));
+        assertThat(matchers, hasItem(UtilMatchers.canMatchPath(workspace.getRoot().resolve("abc.smithy"))));
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/project/ProjectFilePatternsTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/project/ProjectFilePatternsTest.java
@@ -6,7 +6,6 @@
 package software.amazon.smithy.lsp.project;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
@@ -14,6 +13,7 @@ import java.util.HashSet;
 import org.junit.jupiter.api.Test;
 import software.amazon.smithy.build.model.SmithyBuildConfig;
 import software.amazon.smithy.lsp.TestWorkspace;
+import software.amazon.smithy.lsp.UtilMatchers;
 import software.amazon.smithy.utils.ListUtils;
 
 public class ProjectFilePatternsTest {
@@ -42,10 +42,10 @@ public class ProjectFilePatternsTest {
         PathMatcher buildMatcher = ProjectFilePatterns.getBuildFilesPathMatcher(project);
 
         Path root = project.root();
-        assertThat(smithyMatcher.matches(root.resolve("abc.smithy")), is(true));
-        assertThat(smithyMatcher.matches(root.resolve("foo/bar/baz.smithy")), is(true));
-        assertThat(smithyMatcher.matches(root.resolve("other/bar.smithy")), is(true));
-        assertThat(buildMatcher.matches(root.resolve("smithy-build.json")), is(true));
-        assertThat(buildMatcher.matches(root.resolve(".smithy-project.json")), is(true));
+        assertThat(smithyMatcher, UtilMatchers.canMatchPath(root.resolve("abc.smithy")));
+        assertThat(smithyMatcher, UtilMatchers.canMatchPath(root.resolve("foo/bar/baz.smithy")));
+        assertThat(smithyMatcher, UtilMatchers.canMatchPath(root.resolve("other/bar.smithy")));
+        assertThat(buildMatcher, UtilMatchers.canMatchPath(root.resolve("smithy-build.json")));
+        assertThat(buildMatcher, UtilMatchers.canMatchPath(root.resolve(".smithy-project.json")));
     }
 }

--- a/src/test/java/software/amazon/smithy/lsp/project/ProjectManagerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/project/ProjectManagerTest.java
@@ -21,7 +21,7 @@ public class ProjectManagerTest {
         Project mainProject = ProjectLoader.load(attachedRoot).unwrap();
 
         ProjectManager manager = new ProjectManager();
-        manager.updateMainProject(mainProject);
+        manager.updateProjectByName("main", mainProject);
 
         String detachedUri = LspAdapter.toUri("/foo/bar");
         manager.createDetachedProject(detachedUri, "");


### PR DESCRIPTION
Previously, the language server only knew about a single workspace root, so if your editor was using [WorkspaceFolders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_workspaceFolders) the server would just pick the first one, and not load any others. This commit allows the server to load multiple workspaces. The primary challenge was handling state changes to individual workspaces independently. We use client-side file watchers and the `didChangeWatchedFiles` notification to make sure projects are up to date with new and deleted Smithy files, and any changes to build files (i.e. smithy-build.json). `didChangeWatchedFiles` sends a flat list of file events - not partitioned by workspace - so we have to figure out which projects each change applies to. This is done by creating a `PathMatcher` for each project's smithy files and build files, then matching on each file event. This way, we can apply changes to each individual project, rather than reloading everything. Selectors were also updated to select from all available projects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
