### PR TITLE
 Add ShapeId as detail in completions 

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/handler/CompletionHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/handler/CompletionHandler.java
@@ -238,6 +238,7 @@ public final class CompletionHandler {
             DocumentId id
     ) {
         CompletionItem completionItem = new CompletionItem(label);
+        completionItem.setDetail(shapeId.toString());
         completionItem.setKind(CompletionItemKind.Class);
         TextEdit textEdit = new TextEdit(id.range(), label);
         completionItem.setTextEdit(Either.forLeft(textEdit));

--- a/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
@@ -35,6 +35,21 @@ public final class LspMatchers {
         };
     }
 
+    public static Matcher<CompletionItem> hasDetail(String detail) {
+        return new CustomTypeSafeMatcher<>("a completion item with the detail + `" + detail + "`") {
+            @Override
+            protected boolean matchesSafely(CompletionItem item) {
+                return item.getDetail().equals(detail);
+            }
+
+            @Override
+            public void describeMismatchSafely(CompletionItem item, Description description) {
+                description.appendText("Expected completion item with detail '"
+                                       + detail + "' but was '" + item.getDetail() + "'");
+            }
+        };
+    }
+
     public static Matcher<TextEdit> makesEditedDocument(Document document, String expected) {
         return new CustomTypeSafeMatcher<>("makes an edited document " + expected) {
             @Override

--- a/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/SmithyLanguageServerTest.java
@@ -1,6 +1,7 @@
 package software.amazon.smithy.lsp;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -19,6 +20,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static software.amazon.smithy.lsp.LspMatchers.diagnosticWithMessage;
+import static software.amazon.smithy.lsp.LspMatchers.hasDetail;
 import static software.amazon.smithy.lsp.LspMatchers.hasLabel;
 import static software.amazon.smithy.lsp.LspMatchers.hasText;
 import static software.amazon.smithy.lsp.LspMatchers.makesEditedDocument;
@@ -137,8 +139,8 @@ public class SmithyLanguageServerTest {
         List<CompletionItem> traitCompletions = server.completion(traitParams).get().getLeft();
         List<CompletionItem> wsCompletions = server.completion(wsParams).get().getLeft();
 
-        assertThat(memberTargetCompletions, containsInAnyOrder(hasLabel("String")));
-        assertThat(traitCompletions, containsInAnyOrder(hasLabel("default")));
+        assertThat(memberTargetCompletions, containsInAnyOrder(allOf(hasLabel("String"), hasDetail("smithy.api#String"))));
+        assertThat(traitCompletions, containsInAnyOrder(allOf(hasLabel("default"), hasDetail("smithy.api#default"))));
         assertThat(wsCompletions, empty());
     }
 
@@ -189,7 +191,7 @@ public class SmithyLanguageServerTest {
                 .buildCompletion();
         List<CompletionItem> completions = server.completion(completionParams).get().getLeft();
 
-        assertThat(completions, containsInAnyOrder(hasLabel("Bar")));
+        assertThat(completions, containsInAnyOrder(allOf(hasLabel("Bar"), hasDetail("com.bar#Bar"))));
 
         Document document = server.getFirstProject().getDocument(uri);
         // TODO: The server puts the 'use' on the wrong line
@@ -491,7 +493,7 @@ public class SmithyLanguageServerTest {
                 .buildCompletion();
         List<CompletionItem> completions = server.completion(completionParams).get().getLeft();
 
-        assertThat(completions, hasItem(hasLabel("GetFooInput")));
+        assertThat(completions, hasItem(allOf(hasLabel("GetFooInput"), hasDetail("com.foo#GetFooInput"))));
     }
 
     @Test
@@ -715,7 +717,7 @@ public class SmithyLanguageServerTest {
 
         List<CompletionItem> completions = server.completion(completionParams).get().getLeft();
 
-         assertThat(completions, containsInAnyOrder(hasLabel("Foo")));
+         assertThat(completions, containsInAnyOrder(allOf(hasLabel("Foo"), hasDetail("com.foo#Foo"))));
     }
 
     @Test
@@ -775,7 +777,7 @@ public class SmithyLanguageServerTest {
 
         List<CompletionItem> completions = server.completion(completionParams).get().getLeft();
 
-        assertThat(completions, containsInAnyOrder(hasLabel("Foo")));
+        assertThat(completions, containsInAnyOrder(allOf(hasLabel("Foo"), hasDetail("com.foo#Foo"))));
     }
 
     @Test
@@ -807,7 +809,7 @@ public class SmithyLanguageServerTest {
         String model = safeString("""
                 $version: "2"
                 namespace com.foo
-                
+
                 structure Foo {
                     abc
                 }
@@ -836,7 +838,7 @@ public class SmithyLanguageServerTest {
         String model = safeString("""
                 $version: "2"
                 namespace com.foo
-                
+
                 use mything#SomeUnknownThing
                 """);
         TestWorkspace workspace = TestWorkspace.singleModel(model);
@@ -1768,9 +1770,9 @@ public class SmithyLanguageServerTest {
         List<CompletionItem> traitCompletions = server.completion(trait.buildCompletion()).get().getLeft();
         List<CompletionItem> memberTargetCompletions = server.completion(memberTarget.buildCompletion()).get().getLeft();
 
-        assertThat(useTargetCompletions, containsInAnyOrder(hasLabel("com.bar#Bar2"))); // won't match 'Bar' because its already imported
-        assertThat(traitCompletions, containsInAnyOrder(hasLabel("com.bar#baz")));
-        assertThat(memberTargetCompletions, containsInAnyOrder(hasLabel("com.bar#Bar"), hasLabel("com.bar#Bar2")));
+        assertThat(useTargetCompletions, containsInAnyOrder(allOf(hasLabel("com.bar#Bar2"), hasDetail("com.bar#Bar2")))); // won't match 'Bar' because its already imported
+        assertThat(traitCompletions, containsInAnyOrder(allOf(hasLabel("com.bar#baz"), hasDetail("com.bar#baz"))));
+        assertThat(memberTargetCompletions, containsInAnyOrder(hasLabel("com.bar#Bar"), hasDetail("com.bar#Bar2")));
 
         List<? extends Location> useTargetLocations = server.definition(useTarget.buildDefinition()).get().getLeft();
         List<? extends Location> traitLocations = server.definition(trait.buildDefinition()).get().getLeft();
@@ -1832,7 +1834,7 @@ public class SmithyLanguageServerTest {
                 .get()
                 .getLeft();
 
-        assertThat(completions, containsInAnyOrder(hasLabel("com.bar#Bar")));
+        assertThat(completions, containsInAnyOrder(allOf(hasLabel("com.bar#Bar"), hasDetail("com.bar#Bar"))));
         assertThat(completions.get(0).getAdditionalTextEdits(), nullValue());
     }
 
@@ -1990,7 +1992,7 @@ public class SmithyLanguageServerTest {
         server.didChange(RequestBuilders.didChange()
                 .uri(fooUri)
                 .text("""
-                        
+
                         structure Bar {}""")
                 .range(LspAdapter.point(3, 0))
                 .build());


### PR DESCRIPTION
It can be useful when a given name shows up in many namespaces and you want to choose which one gets imported.

<img width="981" alt="image" src="https://github.com/user-attachments/assets/a650931b-242a-4b0a-b1b6-dd8ab04f485a" />
