### PR TITLE
Add completions for for build files

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/language/BuildCompletionHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/BuildCompletionHandler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import java.util.List;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import software.amazon.smithy.lsp.document.DocumentId;
+import software.amazon.smithy.lsp.project.BuildFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.syntax.NodeCursor;
+import software.amazon.smithy.model.shapes.Shape;
+
+/**
+ * Handles completions requests for {@link BuildFile}s.
+ */
+public final class BuildCompletionHandler {
+    private final Project project;
+    private final BuildFile buildFile;
+
+    public BuildCompletionHandler(Project project, BuildFile buildFile) {
+        this.project = project;
+        this.buildFile = buildFile;
+    }
+
+    /**
+     * @param params The request params
+     * @return A list of possible completions
+     */
+    public List<CompletionItem> handle(CompletionParams params) {
+        Position position = CompletionHandler.getTokenPosition(params);
+        DocumentId id = buildFile.document().copyDocumentId(position);
+        Range insertRange = CompletionHandler.getInsertRange(id, position);
+
+        Shape buildFileShape = Builtins.getBuildFileShape(buildFile.type());
+
+        if (buildFileShape == null) {
+            return List.of();
+        }
+
+        NodeCursor cursor = NodeCursor.create(
+                buildFile.getParse().value(),
+                buildFile.document().indexOfPosition(position)
+        );
+        NodeSearch.Result searchResult = NodeSearch.search(cursor, Builtins.MODEL, buildFileShape);
+        var candidates = CompletionCandidates.fromSearchResult(searchResult);
+
+        var context = CompleterContext.create(id, insertRange, project)
+                .withExclude(searchResult.getOtherPresentKeys());
+        var mapper = new SimpleCompleter.BuildFileMapper(context);
+
+        return new SimpleCompleter(context, mapper).getCompletionItems(candidates);
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/language/Builtins.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/Builtins.java
@@ -8,6 +8,7 @@ package software.amazon.smithy.lsp.language;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
+import software.amazon.smithy.lsp.project.BuildFileType;
 import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
@@ -35,6 +36,7 @@ final class Builtins {
             .addImport(Builtins.class.getResource("control.smithy"))
             .addImport(Builtins.class.getResource("metadata.smithy"))
             .addImport(Builtins.class.getResource("members.smithy"))
+            .addImport(Builtins.class.getResource("build.smithy"))
             .assemble()
             .unwrap();
 
@@ -50,6 +52,10 @@ final class Builtins {
     static final Shape VALIDATORS = MODEL.expectShape(id("BuiltinValidators"));
 
     static final Shape SHAPE_MEMBER_TARGETS = MODEL.expectShape(id("ShapeMemberTargets"));
+
+    static final Shape SMITHY_BUILD_JSON = MODEL.expectShape(id("SmithyBuildJson"));
+
+    static final Shape SMITHY_PROJECT_JSON = MODEL.expectShape(id("SmithyProjectJson"));
 
     static final Map<String, ShapeId> VALIDATOR_CONFIG_MAPPING = VALIDATORS.members().stream()
             .collect(Collectors.toMap(
@@ -102,6 +108,14 @@ final class Builtins {
         return memberTargets.getMember(memberName)
                 .map(memberShape -> MODEL.expectShape(memberShape.getTarget()))
                 .orElse(null);
+    }
+
+    static Shape getBuildFileShape(BuildFileType type) {
+        return switch (type) {
+            case SMITHY_BUILD -> SMITHY_BUILD_JSON;
+            case SMITHY_PROJECT -> SMITHY_PROJECT_JSON;
+            default -> null;
+        };
     }
 
     private static ShapeId id(String name) {

--- a/src/main/java/software/amazon/smithy/lsp/language/CompletionHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/CompletionHandler.java
@@ -96,7 +96,7 @@ public final class CompletionHandler {
         };
     }
 
-    private static Position getTokenPosition(CompletionParams params) {
+    static Position getTokenPosition(CompletionParams params) {
         Position position = params.getPosition();
         CompletionContext context = params.getContext();
         if (context != null
@@ -107,7 +107,7 @@ public final class CompletionHandler {
         return position;
     }
 
-    private static Range getInsertRange(DocumentId id, Position position) {
+    static Range getInsertRange(DocumentId id, Position position) {
         if (id == null || id.idSlice().isEmpty()) {
             // When we receive the completion request, we're always on the
             // character either after what has just been typed, or we're in

--- a/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
@@ -1,0 +1,90 @@
+$version: "2.0"
+
+namespace smithy.lang.server
+
+structure SmithyProjectJson {
+    sources: Strings
+    imports: Strings
+    outputDirectory: String
+    dependencies: ProjectDependencies
+}
+
+list ProjectDependencies {
+    member: ProjectDependency
+}
+
+structure ProjectDependency {
+    name: String
+
+    @required
+    path: String
+}
+
+structure SmithyBuildJson {
+    @required
+    version: SmithyBuildVersion
+
+    outputDirectory: String
+    sources: Strings
+    imports: Strings
+    projections: Projections
+    plugins: Plugins
+    ignoreMissingPlugins: Boolean
+    maven: Maven
+}
+
+@default("1")
+string SmithyBuildVersion
+
+map Projections {
+    key: String
+    value: Projection
+}
+
+structure Projection {
+    abstract: Boolean
+    imports: Strings
+    transforms: Transforms
+    plugins: Plugins
+}
+
+map Plugins {
+    key: String
+    value: Document
+}
+
+list Transforms {
+    member: Transform
+}
+
+structure Transform {
+    @required
+    name: String
+
+    args: TransformArgs
+}
+
+structure TransformArgs {
+}
+
+structure Maven {
+    dependencies: Strings
+    repositories: MavenRepositories
+}
+
+list MavenRepositories {
+    member: MavenRepository
+}
+
+structure MavenRepository {
+    @required
+    url: String
+
+    httpCredentials: String
+    proxyHost: String
+    proxyCredentials: String
+}
+
+list Strings {
+    member: String
+}

--- a/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
@@ -36,6 +36,16 @@ public final class LspMatchers {
         };
     }
 
+    public static Matcher<CompletionItem> hasLabelAndEditText(String label, String editText) {
+        return new CustomTypeSafeMatcher<>("label " + label + " editText " + editText) {
+            @Override
+            protected boolean matchesSafely(CompletionItem item) {
+                return label.equals(item.getLabel())
+                       && editText.trim().equals(item.getTextEdit().getLeft().getNewText().trim());
+            }
+        };
+    }
+
     public static Matcher<TextEdit> makesEditedDocument(Document document, String expected) {
         return new CustomTypeSafeMatcher<>("makes an edited document " + expected) {
             @Override

--- a/src/test/java/software/amazon/smithy/lsp/language/BuildCompletionHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/BuildCompletionHandlerTest.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static software.amazon.smithy.lsp.LspMatchers.hasLabelAndEditText;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.lsp.RequestBuilders;
+import software.amazon.smithy.lsp.TextWithPositions;
+import software.amazon.smithy.lsp.project.BuildFile;
+import software.amazon.smithy.lsp.project.BuildFileType;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.project.ProjectTest;
+import software.amazon.smithy.lsp.protocol.LspAdapter;
+
+public class BuildCompletionHandlerTest {
+    @Test
+    public void completesSmithyBuildJsonTopLevel() {
+        var text = TextWithPositions.from("""
+                {
+                    %
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("version", """
+                        "version": "1"
+                        """),
+                hasLabelAndEditText("outputDirectory", """
+                        "outputDirectory": ""
+                        """),
+                hasLabelAndEditText("sources", """
+                        "sources": []
+                        """),
+                hasLabelAndEditText("imports", """
+                        "imports": []
+                        """),
+                hasLabelAndEditText("projections", """
+                        "projections": {}
+                        """),
+                hasLabelAndEditText("plugins", """
+                        "plugins": {}
+                        """),
+                hasLabelAndEditText("ignoreMissingPlugins", """
+                        "ignoreMissingPlugins":
+                        """),
+                hasLabelAndEditText("maven", """
+                        "maven": {}
+                        """)
+                ));
+    }
+
+    @Test
+    public void completesSmithyBuildJsonProjectionMembers() {
+        var text = TextWithPositions.from("""
+                {
+                    "projections": {
+                        "foo": {
+                            %
+                        }
+                    }
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("abstract", """
+                        "abstract":
+                        """),
+                hasLabelAndEditText("imports", """
+                        "imports": []
+                        """),
+                hasLabelAndEditText("transforms", """
+                        "transforms": []
+                        """),
+                hasLabelAndEditText("plugins", """
+                        "plugins": {}
+                        """)
+        ));
+    }
+
+    @Test
+    public void completesSmithyBuildJsonTransformMembers() {
+        var text = TextWithPositions.from("""
+                {
+                    "projections": {
+                        "foo": {
+                            "transforms": [
+                                {
+                                    %
+                                }
+                            ]
+                        }
+                    }
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("name", """
+                        "name": ""
+                        """),
+                hasLabelAndEditText("args", """
+                        "args": {}
+                        """)
+        ));
+    }
+
+    @Test
+    public void completesSmithyBuildJsonMavenMembers() {
+        var text = TextWithPositions.from("""
+                {
+                    "maven": {
+                        %
+                    }
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("dependencies", """
+                        "dependencies": []
+                        """),
+                hasLabelAndEditText("repositories", """
+                        "repositories": []
+                        """)
+        ));
+    }
+
+    @Test
+    public void completesSmithyBuildJsonMavenRepoMembers() {
+        var text = TextWithPositions.from("""
+                {
+                    "maven": {
+                        "repositories": [
+                            {
+                                %
+                            }
+                        ]
+                    }
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("url", """
+                        "url": ""
+                        """),
+                hasLabelAndEditText("httpCredentials", """
+                        "httpCredentials": ""
+                        """),
+                hasLabelAndEditText("proxyHost", """
+                        "proxyHost": ""
+                        """),
+                hasLabelAndEditText("proxyCredentials", """
+                        "proxyCredentials": ""
+                        """)
+        ));
+    }
+
+    @Test
+    public void completesSmithyProjectJsonTopLevel() {
+        var text = TextWithPositions.from("""
+                {
+                    %
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_PROJECT);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("sources", """
+                        "sources": []
+                        """),
+                hasLabelAndEditText("imports", """
+                        "imports": []
+                        """),
+                hasLabelAndEditText("outputDirectory", """
+                        "outputDirectory": ""
+                        """),
+                hasLabelAndEditText("dependencies", """
+                        "dependencies": []
+                        """)
+        ));
+    }
+
+    @Test
+    public void completesSmithyProjectJsonDependencyMembers() {
+        var text = TextWithPositions.from("""
+                {
+                    "dependencies": [
+                        {
+                            %
+                        }
+                    ]
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_PROJECT);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("name", """
+                        "name": ""
+                        """),
+                hasLabelAndEditText("path", """
+                        "path": ""
+                        """)
+        ));
+    }
+
+    @Test
+    public void matchesStringKeys() {
+        var text = TextWithPositions.from("""
+                {
+                    "v%"
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("version", """
+                        "version": "1"
+                        """)
+        ));
+    }
+
+    @Test
+    public void matchesNonStringKeys() {
+        var text = TextWithPositions.from("""
+                {
+                    v%
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("version", """
+                        "version": "1"
+                        """)
+        ));
+    }
+
+    @Test
+    public void completesKeyValues() {
+        var text = TextWithPositions.from("""
+                {
+                    "version": %,
+                    "projections": {
+                        "a": {
+                            "abstract": %
+                        },
+                        "b": {
+                            "imports": %
+                        },
+                        "c": {
+                            "plugins": %
+                        }
+                    }
+                }
+                """);
+        var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
+
+        assertThat(items, containsInAnyOrder(
+                hasLabelAndEditText("\"1\"", """
+                        "1"
+                        """),
+                hasLabelAndEditText("false", "false"),
+                hasLabelAndEditText("true", "true"),
+                hasLabelAndEditText("[]", "[]"),
+                hasLabelAndEditText("{}", "{}")
+        ));
+    }
+
+    private static List<CompletionItem> getCompItems(TextWithPositions twp, BuildFileType type) {
+        try {
+            Path root = Files.createTempDirectory("test");
+            Path path = root.resolve(type.filename());
+            Files.writeString(path, twp.text());
+            Project project = ProjectTest.load(root);
+            String uri = LspAdapter.toUri(path.toString());
+            BuildFile buildFile = (BuildFile) project.getProjectFile(uri);
+            List<CompletionItem> completionItems = new ArrayList<>();
+            BuildCompletionHandler handler = new BuildCompletionHandler(project, buildFile);
+            for (Position position : twp.positions()) {
+                CompletionParams params = RequestBuilders.positionRequest()
+                        .uri(uri)
+                        .position(position)
+                        .buildCompletion();
+                completionItems.addAll(handler.handle(params));
+            }
+            return completionItems;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
The server now can provide completions for smithy-build.json and .smithy-project.json. The implementation works roughly the same as other node-like completions, using a new builtins model that specifies the structure of the build files. I also had to override the completion item mapper to make sure it wrapped object keys in strings, which is necessary in json.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
