### PR TITLE
Update label details to include fully qualified name in description

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/language/ShapeCompleter.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/ShapeCompleter.java
@@ -130,7 +130,7 @@ record ShapeCompleter(IdlPosition idlPosition, Model model, CompleterContext con
             completionItem.setDetail(shape.getType().toString());
 
             var labelDetails = new CompletionItemLabelDetails();
-            labelDetails.setDetail(shape.getId().getNamespace());
+            labelDetails.setDescription(shape.getId().toString());
             completionItem.setLabelDetails(labelDetails);
 
             TextEdit edit = new TextEdit(insertRange, shapeLabel);


### PR DESCRIPTION
This change better aligns with LSP spec and fixes #194. 

Some clients concatenate the label `detail` with the label as it usually contains param info. Adding the fully qualified name to the description instead fixes this issue.

== Before
<img width="536" alt="Screenshot 2025-02-13 at 1 56 47 PM" src="https://github.com/user-attachments/assets/31e2c610-27c6-48fc-879e-ea1a62562581" />


== After
<img width="677" alt="Screenshot 2025-02-13 at 2 08 39 PM" src="https://github.com/user-attachments/assets/162d3ce0-6e02-4057-b71b-e7e89bc9880e" />



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
