### PR TITLE
Fix rebuilding when SourceLocation is NONE

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/project/Project.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/Project.java
@@ -345,13 +345,15 @@ public final class Project {
             // those traits.
 
             // This shape's dependencies files will be removed and re-loaded
-            this.rebuildIndex.getDependenciesFiles(toShapeId).forEach((depPath) ->
-                    removeFileForReload(assembler, builder, depPath, visited));
+            for (String depPath : this.rebuildIndex.getDependenciesFiles(toShapeId)) {
+                removeFileForReload(assembler, builder, depPath, visited);
+            }
 
             // Traits applied in other files are re-added to the assembler so if/when the shape
             // is reloaded, it will have those traits
-            this.rebuildIndex.getTraitsAppliedInOtherFiles(toShapeId).forEach((trait) ->
-                    assembler.addTrait(toShapeId.toShapeId(), trait));
+            for (Trait trait : this.rebuildIndex.getTraitsAppliedInOtherFiles(toShapeId)) {
+                assembler.addTrait(toShapeId.toShapeId(), trait);
+            }
         }
     }
 
@@ -507,8 +509,9 @@ public final class Project {
                     Node traitNode = traitApplication.toNode();
                     if (traitNode.isArrayNode()) {
                         for (Node element : traitNode.expectArrayNode()) {
-                            String elementSourceFilename = element.getSourceLocation().getFilename();
-                            if (!elementSourceFilename.equals(shapeSourceFilename)) {
+                            SourceLocation elementSourceLocation = element.getSourceLocation();
+                            String elementSourceFilename = elementSourceLocation.getFilename();
+                            if (!isNone(elementSourceLocation) && !elementSourceFilename.equals(shapeSourceFilename)) {
                                 newIndex.filesToDependentFiles
                                         .computeIfAbsent(elementSourceFilename, (f) -> new HashSet<>())
                                         .add(shapeSourceFilename);
@@ -518,8 +521,9 @@ public final class Project {
                             }
                         }
                     } else {
-                        String traitSourceFilename = traitApplication.getSourceLocation().getFilename();
-                        if (!traitSourceFilename.equals(shapeSourceFilename)) {
+                        SourceLocation traitSourceLocation = traitNode.getSourceLocation();
+                        String traitSourceFilename = traitSourceLocation.getFilename();
+                        if (!isNone(traitSourceLocation) && !traitSourceFilename.equals(shapeSourceFilename)) {
                             newIndex.shapesToAppliedTraitsInOtherFiles
                                     .computeIfAbsent(shape.getId(), (i) -> new ArrayList<>())
                                     .add(traitApplication);
@@ -533,6 +537,10 @@ public final class Project {
             }
 
             return newIndex;
+        }
+
+        private static boolean isNone(SourceLocation sourceLocation) {
+            return sourceLocation.equals(SourceLocation.NONE);
         }
     }
 }


### PR DESCRIPTION
The rebuild index checks which shapes have traits that are applied in other files (i.e. via an `apply`), so we can preserve those traits in a reload. However, if a trait's source location is `SourceLocation.NONE`, which can happen if it wasn't set on the trait's builder, the rebuild index would consider that "a trait applied from another file". If the trait isn't actually being applied from another file, this would cause a duplicate trait conflict, since the trait would be added both from the rebuild index, and the ModelAssembler reparsing.

This commit changes two things:
1. The trait's _node_ source location is now used for the comparison, since it should always have a source location as it is constructed within smithy-model, not by trait provider implementations
2. This source location is checked to see if it is NONE.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
