### PR TITLE
Fix trait application and empty string parsing

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
@@ -193,7 +193,6 @@ final class Parser extends SimpleParser {
         while (!eof()) {
             if (is(')')) {
                 setEnd(kvps);
-                skip();
                 return kvps;
             }
 
@@ -398,7 +397,6 @@ final class Parser extends SimpleParser {
             }
 
             // Empty string
-            skip();
             int strEnd = position();
             return new Syntax.Node.Str(start, strEnd, "");
         }

--- a/src/test/java/software/amazon/smithy/lsp/TextWithPositions.java
+++ b/src/test/java/software/amazon/smithy/lsp/TextWithPositions.java
@@ -38,6 +38,8 @@ public record TextWithPositions(String text, Position... positions) {
     public static TextWithPositions from(String raw) {
         Document document = Document.of(safeString(raw));
         List<Position> positions = new ArrayList<>();
+
+        Position lastPosition = null;
         int i = 0;
         while (true) {
             int next = document.nextIndexOf(POSITION_MARKER, i);
@@ -45,6 +47,12 @@ public record TextWithPositions(String text, Position... positions) {
                 break;
             }
             Position position = document.positionAtIndex(next);
+            if (lastPosition != null && position.getLine() == lastPosition.getLine()) {
+                // If there's two or more markers on the same line, any markers after the
+                // first will be off by one when we do the replacement.
+                position.setCharacter(position.getCharacter() - 1);
+            }
+            lastPosition = position;
             positions.add(position);
             i = next + 1;
         }


### PR DESCRIPTION
https://github.com/smithy-lang/smithy-language-server/pull/190 fixed trait application parsing for traits like `@foo()`, making it so the end of the trait doesn't include trailing whitespace. This commit fixes the case for non-empty traits, like `@foo(bar: "")`.

It also fixes parsing of empty strings. Previously the character _after_ the end of the string would be skipped.

I also made `TextWithPositions` work when there are multiple markers on the same line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
