### PR TITLE
Cleanup some noisy logs and debugging in tests

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/ServerState.java
+++ b/src/main/java/software/amazon/smithy/lsp/ServerState.java
@@ -101,8 +101,6 @@ public final class ServerState implements ManagedFiles {
             }
         }
 
-        LOGGER.warning(() -> "Tried to unknown file: " + uri);
-
         return null;
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/project/SmithyBuildExtensions.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/SmithyBuildExtensions.java
@@ -159,8 +159,6 @@ public final class SmithyBuildExtensions implements ToSmithyBuilder<SmithyBuildE
                                 .map(repo -> MavenRepository.builder().url(repo).build())
                                 .collect(Collectors.toList()))
                         .build();
-                LOGGER.warning("Read deprecated `mavenRepositories` in smithy-build.json. Update smithy-build.json to "
-                    + "{\"maven\": {\"repositories\": [{\"url\": \"repo url\"}]}}");
             }
 
             this.maven = config;
@@ -183,8 +181,6 @@ public final class SmithyBuildExtensions implements ToSmithyBuilder<SmithyBuildE
                 config = config.toBuilder()
                         .dependencies(mavenDependencies)
                         .build();
-                LOGGER.warning("Read deprecated `mavenDependencies` in smithy-build.json. Update smithy-build.json to "
-                        + "{\"maven\": {\"dependencies\": [\"dependencyA\", \"dependencyB\"]}}");
             }
             this.maven = config;
             return this;

--- a/src/test/java/software/amazon/smithy/lsp/document/DocumentTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/document/DocumentTest.java
@@ -255,14 +255,6 @@ public class DocumentTest {
     }
 
     @Test
-    public void foo() {
-        Document a = makeDocument("abc");
-        Document b = makeDocument("def\n");
-
-        System.out.println();
-    }
-
-    @Test
     public void getsNextIndexOf() {
         Document document = makeDocument("abc\ndef");
 

--- a/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
@@ -329,9 +329,6 @@ public class IdlParserTest {
     @ParameterizedTest
     @MethodSource("brokenProvider")
     public void broken(String desc, String text, List<String> expectedErrorMessages, List<Syntax.Statement.Type> expectedTypes) {
-        if (desc.equals("trait missing member value")) {
-            System.out.println();
-        }
         Syntax.IdlParseResult parse = Syntax.parseIdl(Document.of(text));
         List<String> errorMessages = parse.errors().stream().map(Syntax.Err::message).toList();
         List<Syntax.Statement.Type> types = parse.statements().stream()


### PR DESCRIPTION
Logging for unknown file in ServerState is unnecessary because it will always log for newly opened detached files, plus callers have to handle a file not being found anyway.

Logging for deprecated properties in SmithyBuildExtensions aren't going to be visible enough to customers to be useful, plus we emit a warning for build exts anyways.

I also had some old debugging code lingering in tests that I cleaned up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
