### PR TITLE
Added Inlay Hint Feature for LSP

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ListIterator;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import software.amazon.smithy.lsp.document.Document;
+import software.amazon.smithy.lsp.syntax.Syntax;
+
+public record InlayHintHandler(Document document,
+                               List<Syntax.Statement> statements,
+                               Range hintRange) {
+
+    private static final String OPERATION_TYPE = "operation";
+    private static final String INPUT_TYPE = "input";
+    private static final String OUTPUT_TYPE = "output";
+    private static final String DEFAULT_INPUT_SUFFIX = "Input";
+    private static final String DEFAULT_OUTPUT_SUFFIX = "Output";
+    private static final String OPERATION_INPUT_SUFFIX = "operationInputSuffix";
+    private static final String OPERATION_OUTPUT_SUFFIX = "operationOutputSuffix";
+
+    /**
+     * Main public handle function in the handler class.
+     *
+     * @return A list of Inlay hints
+     */
+    public List<InlayHint> handle() {
+        return processInlayHints();
+    }
+
+    private IOSuffix getIOSuffix(ListIterator<Syntax.Statement> iterator) {
+        // Default value for IO Suffix
+        String inputSuffix = DEFAULT_INPUT_SUFFIX;
+        String outputSuffix = DEFAULT_OUTPUT_SUFFIX;
+
+        while (iterator.hasNext()) {
+            var statement = iterator.next();
+            // Pattern match used for the following two statement to cast them to ideal Statement or Node type.
+            if (statement instanceof Syntax.Statement.Control control) {
+                if (control.value() instanceof Syntax.Node.Str str) {
+                    String key = control.key().stringValue();
+                    switch (key) {
+                        case OPERATION_INPUT_SUFFIX ->
+                                inputSuffix = str.stringValue();
+
+                        case OPERATION_OUTPUT_SUFFIX ->
+                                outputSuffix = str.stringValue();
+
+                        default ->{
+                        }
+                    }
+                }
+            } else if (statement instanceof Syntax.Statement.ShapeDef) {
+                // Customized suffix can only appear at the head of file. Once hit the shapedef statement, we can break.
+                iterator.previous();
+                break;
+            }
+        }
+        return new IOSuffix(inputSuffix, outputSuffix);
+    }
+
+    private boolean coveredByRange(Syntax.Statement statement, int rangeStart, int rangeEnd) {
+        // Check if the statement is totally or partially covered by range.
+        return statement.end() >= rangeStart && statement.start() <= rangeEnd;
+    }
+
+    private List<InlayHint> processInlayHints() {
+        List<InlayHint> inlayHints = new ArrayList<>();
+        ListIterator<Syntax.Statement> iterator = statements.listIterator();
+        IOSuffix ioSuffix = getIOSuffix(iterator);
+        // Convert the window range into document character index.
+        int rangeStartIndex = document.indexOfPosition(hintRange.getStart());
+        int rangeEndIndex = document.indexOfPosition(hintRange.getEnd());
+
+        while (iterator.hasNext()) {
+            var statement = iterator.next();
+            if (statement instanceof Syntax.Statement.ShapeDef shapeDef &&
+                    shapeDef.shapeType().stringValue().equals(OPERATION_TYPE)) {
+                processBlock(inlayHints,
+                        iterator,
+                        ioSuffix,
+                        shapeDef.shapeName().stringValue(),
+                        rangeStartIndex,
+                        rangeEndIndex);
+            }
+        }
+        return inlayHints;
+    }
+
+    private void processBlock(List<InlayHint> inlayHints,
+                              ListIterator<Syntax.Statement> iterator,
+                              IOSuffix ioSuffix,
+                              String operationName,
+                              int rangeStartIndex,
+                              int rangeEndIndex) {
+
+        var block = iterator.next();
+
+        if (!coveredByRange(block, rangeStartIndex, rangeEndIndex)) {
+            return;
+        }
+        int blockEnd = block.end();
+        while (iterator.hasNext()) {
+            var statement = iterator.next();
+            // if the current statement is not covered by window range, just skip.
+            if (!coveredByRange(statement, rangeStartIndex, rangeEndIndex)) {
+                continue;
+            }
+
+            if (statement.start() >= blockEnd) {
+                iterator.previous();
+                return;
+            }
+
+            if (statement instanceof Syntax.Statement.InlineMemberDef inlineMemberDef) {
+                StringBuilder labelBuilder = new StringBuilder(operationName);
+                switch (inlineMemberDef.name().stringValue()) {
+                    case INPUT_TYPE ->
+                            labelBuilder.append(ioSuffix.inputSuffix());
+
+                    case OUTPUT_TYPE ->
+                            labelBuilder.append(ioSuffix.outputSuffix());
+
+                    default -> {
+                    }
+                }
+                // The start position is right after the inline def statement
+                Position position = document.positionAtIndex(inlineMemberDef.end());
+                InlayHint inlayHint = new InlayHint(position, Either.forLeft(labelBuilder.toString()));
+                inlayHints.add(inlayHint);
+            }
+        }
+    }
+
+    private record IOSuffix(String inputSuffix, String outputSuffix) {
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
@@ -48,15 +48,11 @@ public record InlayHintHandler(Document document,
                 if (control.value() instanceof Syntax.Node.Str str) {
                     String key = control.key().stringValue();
                     String suffix = str.stringValue();
-                    switch (key) {
-                        case OPERATION_INPUT_SUFFIX ->
-                                inputSuffix = suffix;
-
-                        case OPERATION_OUTPUT_SUFFIX ->
-                                outputSuffix = suffix;
-
-                        default -> {
-                        }
+                    if (key.equals(OPERATION_INPUT_SUFFIX)) {
+                        inputSuffix = suffix;
+                    }
+                    else if (key.equals(OPERATION_OUTPUT_SUFFIX)) {
+                        outputSuffix = suffix;
                     }
                 }
             } else if (statement instanceof Syntax.Statement.ShapeDef) {

--- a/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
@@ -50,8 +50,7 @@ public record InlayHintHandler(Document document,
                     String suffix = str.stringValue();
                     if (key.equals(OPERATION_INPUT_SUFFIX)) {
                         inputSuffix = suffix;
-                    }
-                    else if (key.equals(OPERATION_OUTPUT_SUFFIX)) {
+                    } else if (key.equals(OPERATION_OUTPUT_SUFFIX)) {
                         outputSuffix = suffix;
                     }
                 }

--- a/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
@@ -86,16 +86,17 @@ public record InlayHintHandler(Document document,
                 if (!coveredByRange(statement, rangeStartIndex, rangeEndIndex)) {
                     continue;
                 }
-                String inlayHintLabel = "";
-                switch (inlineMemberDef.name().stringValue()) {
-                    case INPUT_TYPE ->
-                            inlayHintLabel = lastOperationName + ioSuffix.inputSuffix();
-                    case OUTPUT_TYPE ->
-                            inlayHintLabel = lastOperationName + ioSuffix.outputSuffix();
-                    default -> {
-                        continue;
-                    }
+
+                String inlayHintLabel = switch (inlineMemberDef.name().stringValue()) {
+                    case INPUT_TYPE -> lastOperationName + ioSuffix.inputSuffix();
+                    case OUTPUT_TYPE -> lastOperationName + ioSuffix.outputSuffix();
+                    default -> null;
+                };
+
+                if (inlayHintLabel == null) {
+                    continue;
                 }
+
                 Position position = document.positionAtIndex(inlineMemberDef.end());
                 InlayHint inlayHint = new InlayHint(position, Either.forLeft(inlayHintLabel));
                 inlayHints.add(inlayHint);

--- a/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
@@ -81,6 +81,7 @@ public record InlayHintHandler(Document document,
             if (statement instanceof Syntax.Statement.ShapeDef shapeDef
                     && shapeDef.shapeType().stringValue().equals(OPERATION_TYPE)) {
                 lastOperationName = shapeDef.shapeName().stringValue();
+                continue;
             }
             if (statement instanceof Syntax.Statement.InlineMemberDef inlineMemberDef) {
                 if (!coveredByRange(statement, rangeStartIndex, rangeEndIndex)) {

--- a/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/InlayHintHandler.java
@@ -47,14 +47,15 @@ public record InlayHintHandler(Document document,
             if (statement instanceof Syntax.Statement.Control control) {
                 if (control.value() instanceof Syntax.Node.Str str) {
                     String key = control.key().stringValue();
+                    String suffix = str.stringValue();
                     switch (key) {
                         case OPERATION_INPUT_SUFFIX ->
-                                inputSuffix = str.stringValue();
+                                inputSuffix = suffix;
 
                         case OPERATION_OUTPUT_SUFFIX ->
-                                outputSuffix = str.stringValue();
+                                outputSuffix = suffix;
 
-                        default ->{
+                        default -> {
                         }
                     }
                 }
@@ -82,8 +83,8 @@ public record InlayHintHandler(Document document,
 
         while (iterator.hasNext()) {
             var statement = iterator.next();
-            if (statement instanceof Syntax.Statement.ShapeDef shapeDef &&
-                    shapeDef.shapeType().stringValue().equals(OPERATION_TYPE)) {
+            if (statement instanceof Syntax.Statement.ShapeDef shapeDef
+                    && shapeDef.shapeType().stringValue().equals(OPERATION_TYPE)) {
                 processBlock(inlayHints,
                         iterator,
                         ioSuffix,

--- a/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
@@ -8,6 +8,8 @@ package software.amazon.smithy.lsp;
 import java.util.Collection;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.hamcrest.CustomTypeSafeMatcher;
@@ -128,6 +130,30 @@ public final class LspMatchers {
             @Override
             public void describeMismatchSafely(Diagnostic event, Description description) {
                 description.appendDescriptionOf(message).appendText("was " + event.getMessage());
+            }
+        };
+    }
+
+    public static Matcher<InlayHint> inlayHint(String label, Position position) {
+        return new CustomTypeSafeMatcher<>("Inlay Hint label " + label + " position " +
+                position.getLine() + "," + position.getCharacter()) {
+            @Override
+            protected boolean matchesSafely(InlayHint item) {
+                return item.getLabel().getLeft().equals(label) && position.equals(item.getPosition());
+            }
+            @Override
+            public void describeMismatchSafely(InlayHint item, Description description) {
+                if (!item.getLabel().getLeft().equals(label)) {
+                    description.appendText("Expected inlay hint item with label '"
+                            + label + "' but was '" + item.getLabel().getLeft() + "'");
+                }
+                if (!position.equals(item.getPosition())) {
+                    description.appendText("Expected inlay hint item with position '"
+                            + position.getLine() + "," + position.getCharacter()
+                            + "' but was '" + item.getPosition().getLine()
+                            + "," + item.getPosition().getCharacter()+ "'");
+                }
+
             }
         };
     }

--- a/src/test/java/software/amazon/smithy/lsp/language/InlayHintHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/InlayHintHandlerTest.java
@@ -1,0 +1,350 @@
+package software.amazon.smithy.lsp.language;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.lsp.ServerState;
+import software.amazon.smithy.lsp.TestWorkspace;
+import software.amazon.smithy.lsp.TextWithPositions;
+import software.amazon.smithy.lsp.project.IdlFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.project.ProjectLoader;
+import software.amazon.smithy.lsp.project.ProjectTest;
+
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class InlayHintHandlerTest {
+    @Test
+    public void inlayHintForInlineOperationWithCustomizedSuffix() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                $operationInputSuffix: "Request"
+                $operationOutputSuffix: "Response"
+                
+                namespace smithy.example
+                
+                operation GetUser {
+                    input :=% {
+                        userId: String
+                    }
+                
+                    output :=% {
+                        username: String
+                        userId: String
+                    }
+                }
+                %
+                """);
+        Position startPosition = new Position(0,0);
+        Position endPosition = new Position(model.positions()[2].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        var positions = model.positions();
+        assertThat(hints, hasSize(2));
+        assertEquals(hints.get(0).getPosition(), new Position(positions[0].getLine(), positions[0].getCharacter()));
+        assertEquals(hints.get(1).getPosition(), new Position(positions[1].getLine(), positions[1].getCharacter()));
+        assertEquals("GetUserRequest", hints.get(0).getLabel().getLeft());
+        assertEquals("GetUserResponse", hints.get(1).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForInlineOperationWithoutCustomizedSuffix() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                namespace smithy.example
+                
+                operation GetUser {
+                    input :=% {
+                        userId: String
+                    }
+                
+                    output :=% {
+                        username: String
+                        userId: String
+                    }
+                }
+                %
+                """);
+        Position startPosition = new Position(0,0);
+        Position endPosition = new Position(model.positions()[2].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        var positions = model.positions();
+        assertThat(hints, hasSize(2));
+        assertEquals(hints.get(0).getPosition(), new Position(positions[0].getLine(), positions[0].getCharacter()));
+        assertEquals(hints.get(1).getPosition(), new Position(positions[1].getLine(), positions[1].getCharacter()));
+        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
+        assertEquals("GetUserOutput", hints.get(1).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForInputInlineOperation() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                namespace smithy.example
+                
+                operation GetUser {
+                    input :=% {
+                        userId: String
+                    }
+                }
+                %
+                """);
+        Position startPosition = new Position(0,0);
+        Position endPosition = new Position(model.positions()[1].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        var positions = model.positions();
+        assertThat(hints, hasSize(1));
+        assertEquals(new Position(positions[0].getLine(), positions[0].getCharacter()), hints.get(0).getPosition());
+        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForInputInlineOperationWithMismatchedSuffix() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                namespace smithy.example
+                $operationOutputSuffix: "Response"
+                
+                operation GetUser {
+                    input :=% {
+                        userId: String
+                    }
+                }
+                %
+                """);
+        Position startPosition = new Position(0,0);
+        Position endPosition = new Position(model.positions()[1].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        var positions = model.positions();
+        assertThat(hints, hasSize(1));
+        assertEquals(new Position(positions[0].getLine(), positions[0].getCharacter()), hints.get(0).getPosition());
+        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForOperationWithoutInlineMemberDef() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                namespace smithy.example
+                $operationOutputSuffix: "Response"
+                
+                operation GetUser {
+                }
+                %
+                """);
+        Position startPosition = new Position(0,0);
+        Position endPosition = new Position(model.positions()[0].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(0));
+    }
+
+    @Test
+    public void inlayHintForInlineOperationOffRangeSuffix() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                $operationInputSuffix: "Request"
+                $operationOutputSuffix: "Response"
+                
+                namespace smithy.example
+                
+                %operation GetUser {
+                    input :=% {
+                        userId: String
+                    }
+                
+                    output :=% {
+                        username: String
+                        userId: String
+                    }
+                }
+                %
+                """);
+        var positions = model.positions();
+        Position startPosition = new Position(positions[0].getLine(),0);
+        Position endPosition = new Position(positions[3].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(2));
+        assertEquals(new Position(positions[1].getLine(), positions[1].getCharacter()), hints.get(0).getPosition());
+        assertEquals("GetUserRequest", hints.get(0).getLabel().getLeft());
+        assertEquals(new Position(positions[2].getLine(), positions[2].getCharacter()), hints.get(1).getPosition());
+        assertEquals("GetUserResponse", hints.get(1).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForInlineOperationPartiallyInRange() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                $operationInputSuffix: "Request"
+                $operationOutputSuffix: "Response"
+                
+                namespace smithy.example
+                
+                %operation GetUser {
+                    input :=% {
+                        userId: String
+                    }
+                %
+                    output := {
+                        username: String
+                        userId: String
+                    }
+                }
+                """);
+        var positions = model.positions();
+        Position startPosition = new Position(positions[0].getLine(),0);
+        Position endPosition = new Position(positions[2].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(1));
+        assertEquals(new Position(positions[1].getLine(), positions[1].getCharacter()), hints.get(0).getPosition());
+        assertEquals("GetUserRequest", hints.get(0).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForInlineOperationNotInRange() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                operation GetUser {
+                    input := {
+                        userId: String
+                    }
+                
+                %    output := {
+                        username: String
+                        userId: String
+                    }
+                }
+                %
+                """);
+        var positions = model.positions();
+        Position startPosition = new Position(positions[0].getLine(),0);
+        Position endPosition = new Position(positions[1].getLine(),0);
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(1));
+        assertEquals("GetUserOutput", hints.get(0).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForInlineOperationInOneLine() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                operation GetUser {
+                    input := {
+                        userId: String
+                    }
+                
+                %    output :=% {
+                        username: String
+                        userId: String
+                    }
+                }
+                
+                """);
+        var positions = model.positions();
+        Position startPosition = new Position(positions[0].getLine(),positions[0].getCharacter());
+        Position endPosition = new Position(positions[1].getLine(),positions[1].getCharacter());
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(1));
+        assertEquals("GetUserOutput", hints.get(0).getLabel().getLeft());
+    }
+
+    @Test
+    public void inlayHintForMultipleInlineOperations() {
+        TextWithPositions model = TextWithPositions.from("""
+                %$version: "2"
+                
+                operation GetUser {
+                    input := {
+                        userId: String
+                    }
+                
+                    output := {
+                        username: String
+                        userId: String
+                    }
+                }
+                
+                operation GetAddress {
+                    input := {
+                        userId: String
+                    }
+                
+                   output := {
+                        address: String
+                    }
+                }
+                %
+                """);
+        var positions = model.positions();
+        Position startPosition = new Position(positions[0].getLine(),positions[0].getCharacter());
+        Position endPosition = new Position(positions[1].getLine(),positions[1].getCharacter());
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(4));
+        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
+        assertEquals("GetUserOutput", hints.get(1).getLabel().getLeft());
+        assertEquals("GetAddressInput", hints.get(2).getLabel().getLeft());
+        assertEquals("GetAddressOutput", hints.get(3).getLabel().getLeft());
+
+    }
+
+    @Test
+    public void inlayHintForMultipleInlineOperationWithLimitedRange() {
+        TextWithPositions model = TextWithPositions.from("""
+                $version: "2"
+                
+                operation GetUser {
+                    input := {
+                        userId: String
+                    }
+                
+                    output := {
+                        username: String
+                        userId: String
+                    }
+                }
+                structure foo{
+                    id: String
+                }
+                
+                %operation GetAddress {
+                    input := %{
+                        userId: String
+                    }
+                
+                    output := {
+                        address: String
+                    }
+                }
+                
+                """);
+        var positions = model.positions();
+        Position startPosition = new Position(positions[0].getLine(),positions[0].getCharacter());
+        Position endPosition = new Position(positions[1].getLine(),positions[1].getCharacter());
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(1));
+        assertEquals("GetAddressInput", hints.get(0).getLabel().getLeft());
+    }
+
+    private static List<InlayHint> getInlayHints(String text, Position startPosition, Position endPosition) {
+        TestWorkspace workspace = TestWorkspace.singleModel(text);
+        Project project = ProjectTest.load(workspace.getRoot());
+        String uri = workspace.getUri("main.smithy");
+        IdlFile idlFile = (IdlFile) project.getProjectFile(uri);
+
+        var handler = new InlayHintHandler(idlFile.document(),
+                idlFile.getParse().statements(),
+                new Range(startPosition, endPosition));
+        List<InlayHint> hints = handler.handle();
+        return hints;
+    }
+}

--- a/src/test/java/software/amazon/smithy/lsp/language/InlayHintHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/InlayHintHandlerTest.java
@@ -5,7 +5,9 @@ import java.util.List;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.services.TextDocumentService;
 import org.junit.jupiter.api.Test;
+import software.amazon.smithy.lsp.LspMatchers;
 import software.amazon.smithy.lsp.ServerState;
 import software.amazon.smithy.lsp.TestWorkspace;
 import software.amazon.smithy.lsp.TextWithPositions;
@@ -16,6 +18,7 @@ import software.amazon.smithy.lsp.project.ProjectTest;
 
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -41,15 +44,16 @@ public class InlayHintHandlerTest {
                 }
                 %
                 """);
-        Position startPosition = new Position(0,0);
-        Position endPosition = new Position(model.positions()[2].getLine(),0);
-        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         var positions = model.positions();
+        Position startPosition = new Position(0,0);
+        Position endPosition = positions[2];
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(2));
-        assertEquals(hints.get(0).getPosition(), new Position(positions[0].getLine(), positions[0].getCharacter()));
-        assertEquals(hints.get(1).getPosition(), new Position(positions[1].getLine(), positions[1].getCharacter()));
-        assertEquals("GetUserRequest", hints.get(0).getLabel().getLeft());
-        assertEquals("GetUserResponse", hints.get(1).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserRequest", positions[0]),
+                LspMatchers.inlayHint("GetUserResponse", positions[1])
+        ));
+
     }
 
     @Test
@@ -71,15 +75,15 @@ public class InlayHintHandlerTest {
                 }
                 %
                 """);
-        Position startPosition = new Position(0,0);
-        Position endPosition = new Position(model.positions()[2].getLine(),0);
-        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         var positions = model.positions();
+        Position startPosition = new Position(0,0);
+        Position endPosition = positions[2];
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(2));
-        assertEquals(hints.get(0).getPosition(), new Position(positions[0].getLine(), positions[0].getCharacter()));
-        assertEquals(hints.get(1).getPosition(), new Position(positions[1].getLine(), positions[1].getCharacter()));
-        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
-        assertEquals("GetUserOutput", hints.get(1).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserInput", positions[0]),
+                LspMatchers.inlayHint("GetUserOutput", positions[1])
+        ));
     }
 
     @Test
@@ -96,13 +100,14 @@ public class InlayHintHandlerTest {
                 }
                 %
                 """);
-        Position startPosition = new Position(0,0);
-        Position endPosition = new Position(model.positions()[1].getLine(),0);
-        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         var positions = model.positions();
+        Position startPosition = new Position(0,0);
+        Position endPosition = positions[1];
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(1));
-        assertEquals(new Position(positions[0].getLine(), positions[0].getCharacter()), hints.get(0).getPosition());
-        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserInput", positions[0])
+        ));
     }
 
     @Test
@@ -120,13 +125,14 @@ public class InlayHintHandlerTest {
                 }
                 %
                 """);
-        Position startPosition = new Position(0,0);
-        Position endPosition = new Position(model.positions()[1].getLine(),0);
-        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         var positions = model.positions();
+        Position startPosition = new Position(0,0);
+        Position endPosition = positions[1];
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(1));
-        assertEquals(new Position(positions[0].getLine(), positions[0].getCharacter()), hints.get(0).getPosition());
-        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserInput", positions[0])
+        ));
     }
 
     @Test
@@ -141,8 +147,9 @@ public class InlayHintHandlerTest {
                 }
                 %
                 """);
+        var positions = model.positions();
         Position startPosition = new Position(0,0);
-        Position endPosition = new Position(model.positions()[0].getLine(),0);
+        Position endPosition = positions[0];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(0));
     }
@@ -169,14 +176,14 @@ public class InlayHintHandlerTest {
                 %
                 """);
         var positions = model.positions();
-        Position startPosition = new Position(positions[0].getLine(),0);
-        Position endPosition = new Position(positions[3].getLine(),0);
+        Position startPosition = positions[0];
+        Position endPosition = positions[3];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(2));
-        assertEquals(new Position(positions[1].getLine(), positions[1].getCharacter()), hints.get(0).getPosition());
-        assertEquals("GetUserRequest", hints.get(0).getLabel().getLeft());
-        assertEquals(new Position(positions[2].getLine(), positions[2].getCharacter()), hints.get(1).getPosition());
-        assertEquals("GetUserResponse", hints.get(1).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserRequest", positions[1]),
+                LspMatchers.inlayHint("GetUserResponse", positions[2])
+        ));
     }
 
     @Test
@@ -200,12 +207,13 @@ public class InlayHintHandlerTest {
                 }
                 """);
         var positions = model.positions();
-        Position startPosition = new Position(positions[0].getLine(),0);
-        Position endPosition = new Position(positions[2].getLine(),0);
+        Position startPosition =positions[0];
+        Position endPosition = positions[2];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(1));
-        assertEquals(new Position(positions[1].getLine(), positions[1].getCharacter()), hints.get(0).getPosition());
-        assertEquals("GetUserRequest", hints.get(0).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserRequest", positions[1])
+        ));
     }
 
     @Test
@@ -218,7 +226,7 @@ public class InlayHintHandlerTest {
                         userId: String
                     }
                 
-                %    output := {
+                %    output :=% {
                         username: String
                         userId: String
                     }
@@ -226,11 +234,13 @@ public class InlayHintHandlerTest {
                 %
                 """);
         var positions = model.positions();
-        Position startPosition = new Position(positions[0].getLine(),0);
-        Position endPosition = new Position(positions[1].getLine(),0);
+        Position startPosition =positions[0];
+        Position endPosition =positions[1];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(1));
-        assertEquals("GetUserOutput", hints.get(0).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserOutput", positions[1])
+        ));
     }
 
     @Test
@@ -251,11 +261,13 @@ public class InlayHintHandlerTest {
                 
                 """);
         var positions = model.positions();
-        Position startPosition = new Position(positions[0].getLine(),positions[0].getCharacter());
-        Position endPosition = new Position(positions[1].getLine(),positions[1].getCharacter());
+        Position startPosition = positions[0];
+        Position endPosition = positions[1];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(1));
-        assertEquals("GetUserOutput", hints.get(0).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserOutput", positions[1])
+        ));
     }
 
     @Test
@@ -264,37 +276,38 @@ public class InlayHintHandlerTest {
                 %$version: "2"
                 
                 operation GetUser {
-                    input := {
+                    input :=% {
                         userId: String
                     }
                 
-                    output := {
+                    output :=% {
                         username: String
                         userId: String
                     }
                 }
                 
                 operation GetAddress {
-                    input := {
+                    input :=% {
                         userId: String
                     }
                 
-                   output := {
+                   output :=% {
                         address: String
                     }
                 }
                 %
                 """);
         var positions = model.positions();
-        Position startPosition = new Position(positions[0].getLine(),positions[0].getCharacter());
-        Position endPosition = new Position(positions[1].getLine(),positions[1].getCharacter());
+        Position startPosition = positions[0];
+        Position endPosition = positions[5];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(4));
-        assertEquals("GetUserInput", hints.get(0).getLabel().getLeft());
-        assertEquals("GetUserOutput", hints.get(1).getLabel().getLeft());
-        assertEquals("GetAddressInput", hints.get(2).getLabel().getLeft());
-        assertEquals("GetAddressOutput", hints.get(3).getLabel().getLeft());
-
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserInput", positions[1]),
+                LspMatchers.inlayHint("GetUserOutput", positions[2]),
+                LspMatchers.inlayHint("GetAddressInput", positions[3]),
+                LspMatchers.inlayHint("GetAddressOutput", positions[4])
+        ));
     }
 
     @Test
@@ -317,7 +330,7 @@ public class InlayHintHandlerTest {
                 }
                 
                 %operation GetAddress {
-                    input := %{
+                    input :=% {
                         userId: String
                     }
                 
@@ -328,11 +341,56 @@ public class InlayHintHandlerTest {
                 
                 """);
         var positions = model.positions();
-        Position startPosition = new Position(positions[0].getLine(),positions[0].getCharacter());
-        Position endPosition = new Position(positions[1].getLine(),positions[1].getCharacter());
+        Position startPosition = positions[0];
+        Position endPosition = positions[1];
         List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
         assertThat(hints, hasSize(1));
-        assertEquals("GetAddressInput", hints.get(0).getLabel().getLeft());
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetAddressInput", positions[1])
+        ));
+    }
+
+    @Test
+    public void inlayHintsForInlineOperationWithMixinAndFor() {
+        TextWithPositions model = TextWithPositions.from("""
+                %$version: "2"
+                
+                operation GetUser {
+                    output :=% for foo with [bar] {
+                            @required
+                            check: Boolean
+                        }
+                }
+                %
+                """);
+        var positions = model.positions();
+        Position startPosition = positions[0];
+        Position endPosition = positions[2];
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(1));
+        assertEquals("GetUserOutput", hints.get(0).getLabel().getLeft());
+        assertEquals(positions[1], hints.get(0).getPosition());
+
+    }
+
+    @Test
+    public void inlayHintsForInvalidInlineOperation() {
+        TextWithPositions model = TextWithPositions.from("""
+                %$version: "2"
+                
+                operation GetUser {
+                    output :=% test
+                }
+                %
+                """);
+        var positions = model.positions();
+        Position startPosition = positions[0];
+        Position endPosition = positions[1];
+        List<InlayHint>hints = getInlayHints(model.text(), startPosition, endPosition);
+        assertThat(hints, hasSize(1));
+        assertThat(hints, contains(
+                LspMatchers.inlayHint("GetUserOutput", positions[1])
+        ));
     }
 
     private static List<InlayHint> getInlayHints(String text, Position startPosition, Position endPosition) {
@@ -344,7 +402,6 @@ public class InlayHintHandlerTest {
         var handler = new InlayHintHandler(idlFile.document(),
                 idlFile.getParse().statements(),
                 new Range(startPosition, endPosition));
-        List<InlayHint> hints = handler.handle();
-        return hints;
+        return handler.handle();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
Issue #169 
*Description of changes:*
Added Inlay hints feature to LSP for the operation shapes. For example, if operation foo has inline definition for input, LSP will generate "fooInput" inlay hint right after the inline definition.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
