### PR TITLE
Add hover for smithy-build.json

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/language/BuildHoverHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/BuildHoverHandler.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import java.util.Optional;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.Position;
+import software.amazon.smithy.lsp.project.BuildFile;
+import software.amazon.smithy.lsp.syntax.NodeCursor;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.DocumentationTrait;
+import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
+
+/**
+ * Handles hover requests for build files.
+ */
+public final class BuildHoverHandler {
+    private final BuildFile buildFile;
+
+    public BuildHoverHandler(BuildFile buildFile) {
+        this.buildFile = buildFile;
+    }
+
+    /**
+     * @param params The request params
+     * @return The hover content
+     */
+    public Hover handle(HoverParams params) {
+        Shape buildFileShape = Builtins.getBuildFileShape(buildFile.type());
+
+        if (buildFileShape == null) {
+            return null;
+        }
+
+        Position position = params.getPosition();
+        NodeCursor cursor = NodeCursor.create(
+                buildFile.getParse().value(),
+                buildFile.document().indexOfPosition(position)
+        );
+        NodeSearch.Result searchResult = NodeSearch.search(cursor, Builtins.MODEL, buildFileShape);
+
+        return getMemberShape(searchResult)
+                .map(BuildHoverHandler::withShapeDocs)
+                .orElse(null);
+    }
+
+    private static Optional<MemberShape> getMemberShape(NodeSearch.Result searchResult) {
+        // We only provide hover on properties (json keys). Otherwise, the hover content could
+        // be noisy if your cursor is just sitting somewhere.
+        if (searchResult instanceof NodeSearch.Result.ObjectKey objectKey) {
+            if (!objectKey.containerShape().isMapShape()) {
+                return objectKey.containerShape().getMember(objectKey.key().name());
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private static Hover withShapeDocs(MemberShape memberShape) {
+        StringBuilder builder = new StringBuilder();
+
+        var docs = memberShape.getTrait(DocumentationTrait.class).orElse(null);
+        var externalDocs = memberShape.getTrait(ExternalDocumentationTrait.class).orElse(null);
+
+        if (docs != null) {
+            builder.append(docs.getValue());
+        }
+
+        if (externalDocs != null) {
+            if (docs != null) {
+                // Add some extra space between regular docs and external
+                builder.append(System.lineSeparator()).append(System.lineSeparator());
+            }
+
+            externalDocs.getUrls()
+                    .forEach((name, url) -> builder.append(String.format("[%s](%s)%n", name, url)));
+        }
+
+        if (builder.isEmpty()) {
+            return null;
+        }
+
+        return new Hover(new MarkupContent("markdown", builder.toString()));
+    }
+}

--- a/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
@@ -21,15 +21,55 @@ structure ProjectDependency {
 }
 
 structure SmithyBuildJson {
+    /// Defines the version of smithy-build. Set to 1.0.
     @required
     version: SmithyBuildVersion
 
+    /// The location where projections are written. Each projection will create a
+    /// subdirectory named after the projection, and the artifacts from the projection,
+    /// including a model.json file, will be placed in the directory.
     outputDirectory: String
+
+    /// Provides a list of relative files or directories that contain the models
+    /// that are considered the source models of the build. When a directory is
+    /// encountered, all files in the entire directory tree are added as sources.
+    /// Sources are relative to the configuration file.
     sources: Strings
+
+    /// Provides a list of model files and directories to load when validating and
+    /// building the model. Imports are a local dependency: they are not considered
+    /// part of model package being built, but are required to build the model package.
+    /// Models added through imports are not present in the output of the built-in
+    /// sources plugin.
+    /// When a directory is encountered, all files in the entire directory tree are
+    /// imported. Imports defined at the top-level are used in every projection.
+    /// Imports are relative to the configuration file.
     imports: Strings
+
+    /// A map of projection names to projection configurations.
+    @externalDocumentation(
+        "Projections Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#projections"
+    )
     projections: Projections
+
+    /// Defines the plugins to apply to the model when building every projection.
+    /// Plugins are a mapping of plugin IDs to plugin-specific configuration objects.
+    @externalDocumentation(
+        "Plugins Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#plugins"
+    )
     plugins: Plugins
+
+    /// If a plugin can't be found, Smithy will by default fail the build. This setting
+    /// can be set to true to allow the build to progress even if a plugin can't be
+    /// found on the classpath.
     ignoreMissingPlugins: Boolean
+
+    /// Defines Java Maven dependencies needed to build the model. Dependencies are
+    /// used to bring in model imports, build plugins, validators, transforms, and
+    /// other extensions.
+    @externalDocumentation(
+        "Maven Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#maven-configuration"
+    )
     maven: Maven
 }
 
@@ -42,9 +82,35 @@ map Projections {
 }
 
 structure Projection {
+    /// Defines the projection as a placeholder that other projections apply. Smithy
+    /// will not build artifacts for abstract projections. Abstract projections must
+    /// not define imports or plugins.
     abstract: Boolean
+
+    /// Provides a list of relative imports to include when building this specific
+    /// projection (in addition to any imports defined at the top-level). When a
+    /// directory is encountered, all files in the directory tree are imported.
+    /// Note: imports are relative to the configuration file.
     imports: Strings
+
+    /// Defines the transformations to apply to the projection. Transformations are
+    /// used to remove shapes, remove traits, modify trait contents, and any other
+    /// kind of transformation necessary for the projection. Transforms are applied
+    /// in the order defined.
+    @externalDocumentation(
+        "Transforms Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#transforms"
+    )
     transforms: Transforms
+
+    /// Defines the plugins to apply to the model when building this projection.
+    /// plugins is a mapping of a plugin IDs to plugin-specific configuration objects.
+    /// smithy-build will attempt to resolve plugin names using Java SPI to locate
+    /// an instance of software.amazon.smithy.build.SmithyBuildPlugin that returns a
+    /// matching name when calling getName. smithy-build will emit a warning when a
+    /// plugin cannot be resolved.
+    @externalDocumentation(
+        "Plugins Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#plugins"
+    )
     plugins: Plugins
 }
 
@@ -58,9 +124,11 @@ list Transforms {
 }
 
 structure Transform {
+    /// The required name of the transform.
     @required
     name: String
 
+    /// A structure that contains configuration key-value pairs.
     args: TransformArgs
 }
 
@@ -68,7 +136,13 @@ structure TransformArgs {
 }
 
 structure Maven {
+    /// A list of Maven dependency coordinates in the form of groupId:artifactId:version.
+    /// The Smithy CLI will search each registered Maven repository for the dependency.
     dependencies: Strings
+
+    /// A list of Maven repositories to search for dependencies. If no repositories
+    /// are defined and the SMITHY_MAVEN_REPOS environment variable is not defined,
+    /// then this value defaults to Maven Central.
     repositories: MavenRepositories
 }
 
@@ -77,11 +151,26 @@ list MavenRepositories {
 }
 
 structure MavenRepository {
+    /// The URL of the repository (for example, https://repo.maven.apache.org/maven2).
     @required
     url: String
 
+    /// HTTP basic or digest credentials to use with the repository. Credentials are
+    /// provided in the form of "username:password".
+    ///
+    /// **WARNING** Credentials SHOULD NOT be defined statically in a smithy-build.json
+    /// file. Instead, use environment variables to keep credentials out of source control.
     httpCredentials: String
+
+    /// The URL of the proxy to configure for this repository (for example,
+    /// http://proxy.maven.apache.org:8080).
     proxyHost: String
+
+    /// HTTP credentials to use with the proxy for the repository. Credentials are
+    /// provided in the form of "username:password".
+    ///
+    /// **WARNING** Credentials SHOULD NOT be defined statically in a smithy-build.json
+    /// file. Instead, use environment variables to keep credentials out of source control.
     proxyCredentials: String
 }
 

--- a/src/test/java/software/amazon/smithy/lsp/language/BuildHoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/BuildHoverHandlerTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.lsp.language;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.lsp.RequestBuilders;
+import software.amazon.smithy.lsp.TestWorkspace;
+import software.amazon.smithy.lsp.TextWithPositions;
+import software.amazon.smithy.lsp.project.BuildFile;
+import software.amazon.smithy.lsp.project.BuildFileType;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.project.ProjectTest;
+
+public class BuildHoverHandlerTest {
+    @Test
+    public void includesDocs() {
+        var twp = TextWithPositions.from("""
+                {
+                    %"version": "1.0"
+                }
+                """);
+        var hovers = getHovers(BuildFileType.SMITHY_BUILD, twp);
+
+        assertThat(hovers, contains(containsString("version")));
+    }
+
+    @Test
+    public void includesExternalDocs() {
+        var twp = TextWithPositions.from("""
+                {
+                    %"projections": {}
+                }
+                """);
+        var hovers = getHovers(BuildFileType.SMITHY_BUILD, twp);
+
+        assertThat(hovers, contains(containsString("https://smithy.io")));
+    }
+
+    @Test
+    public void nested() {
+        var twp = TextWithPositions.from("""
+                {
+                    "maven": {
+                        %"dependencies": []
+                    }
+                }
+                """);
+        var hovers = getHovers(BuildFileType.SMITHY_BUILD, twp);
+
+        assertThat(hovers, contains(containsString("coordinates")));
+    }
+
+    @Test
+    public void noHoverForValues() {
+        var twp = TextWithPositions.from("""
+                %{
+                    "version": %"1.0",
+                    "sources": %[]
+                }
+                """);
+        var hovers = getHovers(BuildFileType.SMITHY_BUILD, twp);
+
+        assertThat(hovers, empty());
+    }
+
+    private static List<String> getHovers(BuildFileType buildFileType, TextWithPositions twp) {
+        var workspace = TestWorkspace.emptyWithNoConfig("test");
+        workspace.addModel(buildFileType.filename(), twp.text());
+
+        Project project = ProjectTest.load(workspace.getRoot());
+        String uri = workspace.getUri(buildFileType.filename());
+        BuildFile buildFile = (BuildFile) project.getProjectFile(uri);
+
+        List<String> hover = new ArrayList<>();
+        BuildHoverHandler handler = new BuildHoverHandler(buildFile);
+        for (Position position : twp.positions()) {
+            HoverParams params = RequestBuilders.positionRequest()
+                    .uri(uri)
+                    .position(position)
+                    .buildHover();
+            Hover result = handler.handle(params);
+            if (result != null) {
+                hover.add(result.getContents().getRight().getValue());
+            }
+        }
+
+        return hover;
+    }
+}


### PR DESCRIPTION
The language server now provides hover content for smithy-build.json. Specifically, when hovering on json keys (and only the keys), hover content will include the documentation for that property from https://smithy.io/2.0/guides/smithy-build-json.html, in addition to a link to the corresponding section in the docs page where applicable.

This uses the `build.smithy` builtin model. I've added documentation traits to all relevant members, including externalDocumentation for the links. I didn't do the same for .smithy-project.json, as I'll need to think through properly documenting that and plan on doing so later.

This commit will have a few followups based on things I've learned from this commit:
1. I should add support for externalDocumentation to IDL hover. Can probably share a lot of the code.
2. I can probably remove the serialization of validation events into IDL hover content. I'm not sure why exactly I put them there, maybe it was an artifact from the history of the language server, but I think that diagnostics are already displayed with hover content, so doing the extra work is unnecessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
