### PR TITLE
Use 1.0 for smithy-build version completion

### DIFF
--- a/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
@@ -33,7 +33,7 @@ structure SmithyBuildJson {
     maven: Maven
 }
 
-@default("1")
+@default("1.0")
 string SmithyBuildVersion
 
 map Projections {

--- a/src/test/java/software/amazon/smithy/lsp/language/BuildCompletionHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/BuildCompletionHandlerTest.java
@@ -38,7 +38,7 @@ public class BuildCompletionHandlerTest {
 
         assertThat(items, containsInAnyOrder(
                 hasLabelAndEditText("version", """
-                        "version": "1"
+                        "version": "1.0"
                         """),
                 hasLabelAndEditText("outputDirectory", """
                         "outputDirectory": ""
@@ -231,7 +231,7 @@ public class BuildCompletionHandlerTest {
 
         assertThat(items, containsInAnyOrder(
                 hasLabelAndEditText("version", """
-                        "version": "1"
+                        "version": "1.0"
                         """)
         ));
     }
@@ -247,7 +247,7 @@ public class BuildCompletionHandlerTest {
 
         assertThat(items, containsInAnyOrder(
                 hasLabelAndEditText("version", """
-                        "version": "1"
+                        "version": "1.0"
                         """)
         ));
     }
@@ -273,8 +273,8 @@ public class BuildCompletionHandlerTest {
         var items = getCompItems(text, BuildFileType.SMITHY_BUILD);
 
         assertThat(items, containsInAnyOrder(
-                hasLabelAndEditText("\"1\"", """
-                        "1"
+                hasLabelAndEditText("\"1.0\"", """
+                        "1.0"
                         """),
                 hasLabelAndEditText("false", "false"),
                 hasLabelAndEditText("true", "true"),


### PR DESCRIPTION
Was just `1`, which doesn't match the docs' default of `1.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
