### PR TITLE
Add missing hover docs

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/language/BuildHoverHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/BuildHoverHandler.java
@@ -8,14 +8,11 @@ package software.amazon.smithy.lsp.language;
 import java.util.Optional;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
-import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.Position;
 import software.amazon.smithy.lsp.project.BuildFile;
 import software.amazon.smithy.lsp.syntax.NodeCursor;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.Shape;
-import software.amazon.smithy.model.traits.DocumentationTrait;
-import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
 
 /**
  * Handles hover requests for build files.
@@ -46,7 +43,7 @@ public final class BuildHoverHandler {
         NodeSearch.Result searchResult = NodeSearch.search(cursor, Builtins.MODEL, buildFileShape);
 
         return getMemberShape(searchResult)
-                .map(BuildHoverHandler::withShapeDocs)
+                .map(HoverHandler::withBuiltinShapeDocs)
                 .orElse(null);
     }
 
@@ -60,32 +57,5 @@ public final class BuildHoverHandler {
         }
 
         return Optional.empty();
-    }
-
-    private static Hover withShapeDocs(MemberShape memberShape) {
-        StringBuilder builder = new StringBuilder();
-
-        var docs = memberShape.getTrait(DocumentationTrait.class).orElse(null);
-        var externalDocs = memberShape.getTrait(ExternalDocumentationTrait.class).orElse(null);
-
-        if (docs != null) {
-            builder.append(docs.getValue());
-        }
-
-        if (externalDocs != null) {
-            if (docs != null) {
-                // Add some extra space between regular docs and external
-                builder.append(System.lineSeparator()).append(System.lineSeparator());
-            }
-
-            externalDocs.getUrls()
-                    .forEach((name, url) -> builder.append(String.format("[%s](%s)%n", name, url)));
-        }
-
-        if (builder.isEmpty()) {
-            return null;
-        }
-
-        return new Hover(new MarkupContent("markdown", builder.toString()));
     }
 }

--- a/src/main/java/software/amazon/smithy/lsp/language/BuildHoverHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/BuildHoverHandler.java
@@ -43,7 +43,7 @@ public final class BuildHoverHandler {
         NodeSearch.Result searchResult = NodeSearch.search(cursor, Builtins.MODEL, buildFileShape);
 
         return getMemberShape(searchResult)
-                .map(HoverHandler::withBuiltinShapeDocs)
+                .flatMap(HoverHandler::withBuiltinShapeDocs)
                 .orElse(null);
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/language/Builtins.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/Builtins.java
@@ -37,6 +37,7 @@ final class Builtins {
             .addImport(Builtins.class.getResource("metadata.smithy"))
             .addImport(Builtins.class.getResource("members.smithy"))
             .addImport(Builtins.class.getResource("build.smithy"))
+            .addImport(Builtins.class.getResource("keywords.smithy"))
             .assemble()
             .unwrap();
 
@@ -56,6 +57,8 @@ final class Builtins {
     static final Shape SMITHY_BUILD_JSON = MODEL.expectShape(id("SmithyBuildJson"));
 
     static final Shape SMITHY_PROJECT_JSON = MODEL.expectShape(id("SmithyProjectJson"));
+
+    static final Shape NON_SHAPE_KEYWORDS = MODEL.expectShape(id("NonShapeKeywords"));
 
     static final Map<String, ShapeId> VALIDATOR_CONFIG_MAPPING = VALIDATORS.members().stream()
             .collect(Collectors.toMap(

--- a/src/main/java/software/amazon/smithy/lsp/language/IdlPosition.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/IdlPosition.java
@@ -70,21 +70,17 @@ sealed interface IdlPosition {
 
     static IdlPosition of(StatementView view) {
         int documentIndex = view.documentIndex();
+
+        if (view.getStatement().isInKeyword(documentIndex)) {
+            return new StatementKeyword(view);
+        }
+
         return switch (view.getStatement()) {
             case Syntax.Statement.Incomplete incomplete
                     when incomplete.ident().isIn(documentIndex) -> new IdlPosition.StatementKeyword(view);
 
-            case Syntax.Statement.ShapeDef shapeDef
-                    when shapeDef.shapeType().isIn(documentIndex) -> new IdlPosition.StatementKeyword(view);
-
-            case Syntax.Statement.Apply apply
-                    when apply.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
-
             case Syntax.Statement.Apply apply
                     when apply.id().isIn(documentIndex) -> new IdlPosition.ApplyTarget(view);
-
-            case Syntax.Statement.Metadata m
-                    when m.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
 
             case Syntax.Statement.Metadata m
                     when m.key().isIn(documentIndex) -> new IdlPosition.MetadataKey(view);
@@ -99,9 +95,6 @@ sealed interface IdlPosition {
                     when t.id().isEmpty() || t.id().isIn(documentIndex) -> new IdlPosition.TraitId(view);
 
             case Syntax.Statement.Use u
-                    when u.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
-
-            case Syntax.Statement.Use u
                     when u.use().isIn(documentIndex) -> new IdlPosition.UseTarget(view);
 
             case Syntax.Statement.MemberDef m
@@ -114,19 +107,10 @@ sealed interface IdlPosition {
                     when m.inValue(documentIndex) -> new IdlPosition.NodeMemberTarget(view, m);
 
             case Syntax.Statement.Namespace n
-                    when n.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
-
-            case Syntax.Statement.Namespace n
                     when n.namespace().isIn(documentIndex) -> new IdlPosition.Namespace(view);
 
             case Syntax.Statement.TraitApplication t
                     when t.value() != null && t.value().isIn(documentIndex) -> new IdlPosition.TraitValue(view, t);
-
-            case Syntax.Statement.Mixins m
-                    when m.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
-
-            case Syntax.Statement.ForResource f
-                    when f.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
 
             case Syntax.Statement.InlineMemberDef m
                     when m.name().isIn(documentIndex) -> new IdlPosition.MemberName(view, m.name().stringValue());

--- a/src/main/java/software/amazon/smithy/lsp/language/IdlPosition.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/IdlPosition.java
@@ -78,7 +78,13 @@ sealed interface IdlPosition {
                     when shapeDef.shapeType().isIn(documentIndex) -> new IdlPosition.StatementKeyword(view);
 
             case Syntax.Statement.Apply apply
+                    when apply.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
+
+            case Syntax.Statement.Apply apply
                     when apply.id().isIn(documentIndex) -> new IdlPosition.ApplyTarget(view);
+
+            case Syntax.Statement.Metadata m
+                    when m.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
 
             case Syntax.Statement.Metadata m
                     when m.key().isIn(documentIndex) -> new IdlPosition.MetadataKey(view);
@@ -93,6 +99,9 @@ sealed interface IdlPosition {
                     when t.id().isEmpty() || t.id().isIn(documentIndex) -> new IdlPosition.TraitId(view);
 
             case Syntax.Statement.Use u
+                    when u.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
+
+            case Syntax.Statement.Use u
                     when u.use().isIn(documentIndex) -> new IdlPosition.UseTarget(view);
 
             case Syntax.Statement.MemberDef m
@@ -105,10 +114,19 @@ sealed interface IdlPosition {
                     when m.inValue(documentIndex) -> new IdlPosition.NodeMemberTarget(view, m);
 
             case Syntax.Statement.Namespace n
+                    when n.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
+
+            case Syntax.Statement.Namespace n
                     when n.namespace().isIn(documentIndex) -> new IdlPosition.Namespace(view);
 
             case Syntax.Statement.TraitApplication t
                     when t.value() != null && t.value().isIn(documentIndex) -> new IdlPosition.TraitValue(view, t);
+
+            case Syntax.Statement.Mixins m
+                    when m.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
+
+            case Syntax.Statement.ForResource f
+                    when f.isInKeyword(documentIndex) -> new IdlPosition.StatementKeyword(view);
 
             case Syntax.Statement.InlineMemberDef m
                     when m.name().isIn(documentIndex) -> new IdlPosition.MemberName(view, m.name().stringValue());

--- a/src/main/java/software/amazon/smithy/lsp/language/IdlPosition.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/IdlPosition.java
@@ -110,6 +110,9 @@ sealed interface IdlPosition {
             case Syntax.Statement.TraitApplication t
                     when t.value() != null && t.value().isIn(documentIndex) -> new IdlPosition.TraitValue(view, t);
 
+            case Syntax.Statement.InlineMemberDef m
+                    when m.name().isIn(documentIndex) -> new IdlPosition.MemberName(view, m.name().stringValue());
+
             case Syntax.Statement.ElidedMemberDef ignored -> new IdlPosition.ElidedMember(view);
 
             case Syntax.Statement.Mixins ignored -> new IdlPosition.Mixin(view);

--- a/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
@@ -367,6 +367,16 @@ public final class Syntax {
             };
         }
 
+        /**
+         * @param pos The character offset in the file to check
+         * @return Whether {@code pos} is within the keyword at the start
+         *  of this statement. Always returns {@code false} if this
+         *  statement doesn't start with a keyword.
+         */
+        public boolean isInKeyword(int pos) {
+            return false;
+        }
+
         public enum Type {
             Incomplete,
             Control,
@@ -443,11 +453,7 @@ public final class Syntax {
                 return value;
             }
 
-            /**
-             * @param pos The character offset in the file to check
-             * @return Whether {@code pos} is within the keyword at the start
-             *  of this statement
-             */
+            @Override
             public boolean isInKeyword(int pos) {
                 return pos >= start && pos < start + "metadata".length();
             }
@@ -467,11 +473,7 @@ public final class Syntax {
                 return namespace;
             }
 
-            /**
-             * @param pos The character offset in the file to check
-             * @return Whether {@code pos} is within the keyword at the start
-             *  of this statement
-             */
+            @Override
             public boolean isInKeyword(int pos) {
                 return pos >= start && pos < start + "namespace".length();
             }
@@ -491,11 +493,7 @@ public final class Syntax {
                 return use;
             }
 
-            /**
-             * @param pos The character offset in the file to check
-             * @return Whether {@code pos} is within the keyword at the start
-             *  of this statement
-             */
+            @Override
             public boolean isInKeyword(int pos) {
                 return pos >= start && pos < start + "use".length();
             }
@@ -516,11 +514,7 @@ public final class Syntax {
                 return id;
             }
 
-            /**
-             * @param pos The character offset in the file to check
-             * @return Whether {@code pos} is within the keyword at the start
-             *  of this statement
-             */
+            @Override
             public boolean isInKeyword(int pos) {
                 return pos >= start && pos < start + "apply".length();
             }
@@ -545,6 +539,11 @@ public final class Syntax {
             public Ident shapeName() {
                 return shapeName;
             }
+
+            @Override
+            public boolean isInKeyword(int pos) {
+                return shapeType.isIn(pos);
+            }
         }
 
         /**
@@ -562,11 +561,7 @@ public final class Syntax {
                 return resource;
             }
 
-            /**
-             * @param pos The character offset in the file to check
-             * @return Whether {@code pos} is within the keyword at the start
-             *  of this statement
-             */
+            @Override
             public boolean isInKeyword(int pos) {
                 return pos >= start && pos < start + "for".length();
             }
@@ -584,11 +579,7 @@ public final class Syntax {
                 return mixins;
             }
 
-            /**
-             * @param pos The character offset in the file to check
-             * @return Whether {@code pos} is within the keyword at the start
-             *  of this statement
-             */
+            @Override
             public boolean isInKeyword(int pos) {
                 return pos >= start && pos < start + "with".length();
             }

--- a/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
@@ -442,6 +442,15 @@ public final class Syntax {
             public Node value() {
                 return value;
             }
+
+            /**
+             * @param pos The character offset in the file to check
+             * @return Whether {@code pos} is within the keyword at the start
+             *  of this statement
+             */
+            public boolean isInKeyword(int pos) {
+                return pos >= start && pos < start + "metadata".length();
+            }
         }
 
         /**
@@ -456,6 +465,15 @@ public final class Syntax {
 
             public Ident namespace() {
                 return namespace;
+            }
+
+            /**
+             * @param pos The character offset in the file to check
+             * @return Whether {@code pos} is within the keyword at the start
+             *  of this statement
+             */
+            public boolean isInKeyword(int pos) {
+                return pos >= start && pos < start + "namespace".length();
             }
         }
 
@@ -472,6 +490,15 @@ public final class Syntax {
             public Ident use() {
                 return use;
             }
+
+            /**
+             * @param pos The character offset in the file to check
+             * @return Whether {@code pos} is within the keyword at the start
+             *  of this statement
+             */
+            public boolean isInKeyword(int pos) {
+                return pos >= start && pos < start + "use".length();
+            }
         }
 
         /**
@@ -487,6 +514,15 @@ public final class Syntax {
 
             public Ident id() {
                 return id;
+            }
+
+            /**
+             * @param pos The character offset in the file to check
+             * @return Whether {@code pos} is within the keyword at the start
+             *  of this statement
+             */
+            public boolean isInKeyword(int pos) {
+                return pos >= start && pos < start + "apply".length();
             }
         }
 
@@ -525,6 +561,15 @@ public final class Syntax {
             public Ident resource() {
                 return resource;
             }
+
+            /**
+             * @param pos The character offset in the file to check
+             * @return Whether {@code pos} is within the keyword at the start
+             *  of this statement
+             */
+            public boolean isInKeyword(int pos) {
+                return pos >= start && pos < start + "for".length();
+            }
         }
 
         /**
@@ -537,6 +582,15 @@ public final class Syntax {
 
             public List<Ident> mixins() {
                 return mixins;
+            }
+
+            /**
+             * @param pos The character offset in the file to check
+             * @return Whether {@code pos} is within the keyword at the start
+             *  of this statement
+             */
+            public boolean isInKeyword(int pos) {
+                return pos >= start && pos < start + "with".length();
             }
         }
 

--- a/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/build.smithy
@@ -20,6 +20,7 @@ structure ProjectDependency {
     path: String
 }
 
+@externalDocumentation("Smithy Build Reference": "https://smithy.io/2.0/guides/smithy-build-json.html")
 structure SmithyBuildJson {
     /// Defines the version of smithy-build. Set to 1.0.
     @required
@@ -81,6 +82,9 @@ map Projections {
     value: Projection
 }
 
+@externalDocumentation(
+    "Projections Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#projections"
+)
 structure Projection {
     /// Defines the projection as a placeholder that other projections apply. Smithy
     /// will not build artifacts for abstract projections. Abstract projections must
@@ -123,6 +127,9 @@ list Transforms {
     member: Transform
 }
 
+@externalDocumentation(
+    "Transforms Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#transforms"
+)
 structure Transform {
     /// The required name of the transform.
     @required
@@ -135,6 +142,9 @@ structure Transform {
 structure TransformArgs {
 }
 
+@externalDocumentation(
+    "Maven Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#maven-configuration"
+)
 structure Maven {
     /// A list of Maven dependency coordinates in the form of groupId:artifactId:version.
     /// The Smithy CLI will search each registered Maven repository for the dependency.
@@ -143,6 +153,9 @@ structure Maven {
     /// A list of Maven repositories to search for dependencies. If no repositories
     /// are defined and the SMITHY_MAVEN_REPOS environment variable is not defined,
     /// then this value defaults to Maven Central.
+    @externalDocumentation(
+        "Maven Repositories Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#maven-repositories"
+    )
     repositories: MavenRepositories
 }
 
@@ -150,6 +163,9 @@ list MavenRepositories {
     member: MavenRepository
 }
 
+@externalDocumentation(
+    "Maven Repositories Reference": "https://smithy.io/2.0/guides/smithy-build-json.html#maven-repositories"
+)
 structure MavenRepository {
     /// The URL of the repository (for example, https://repo.maven.apache.org/maven2).
     @required

--- a/src/main/resources/software/amazon/smithy/lsp/language/keywords.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/keywords.smithy
@@ -1,0 +1,49 @@
+$version: "2.0"
+
+namespace smithy.lang.server
+
+union NonShapeKeywords {
+    /// Metadata is a schema-less extensibility mechanism used to associate metadata to
+    /// an entire model.
+    @externalDocumentation(
+        "Metadata Reference": "https://smithy.io/2.0/spec/model.html#model-metadata"
+    )
+    metadata: Unit
+
+    /// A namespace is a mechanism for logically grouping shapes in a way that makes them
+    /// reusable alongside other models without naming conflicts.
+    @externalDocumentation(
+        "Namespace Statement Reference": "https://smithy.io/2.0/spec/idl.html#namespaces"
+        "Shape ID Reference": "https://smithy.io/2.0/spec/model.html#shape-id"
+    )
+    namespace: Unit
+
+    /// The use section of the IDL is used to import shapes into the current namespace so
+    /// that they can be referred to using a relative shape ID.
+    @externalDocumentation(
+        "Use Statement Reference": "https://smithy.io/2.0/spec/idl.html#referring-to-shapes"
+    )
+    use: Unit
+
+    /// Applies a trait to a shape outside of the shape's definition
+    @externalDocumentation(
+        "Apply Statement Reference": "https://smithy.io/2.0/spec/idl.html#apply-statement"
+        "Applying Traits Reference": "https://smithy.io/2.0/spec/model.html#applying-traits"
+    )
+    apply: Unit
+
+    /// Allows referencing a resource's identifiers and properties in members to create
+    /// resource bindings using target elision syntax.
+    @externalDocumentation(
+        "Identifier Bindings Reference": "https://smithy.io/2.0/spec/service-types.html#binding-identifiers-to-operations"
+        "Property Bindings Reference": "https://smithy.io/2.0/spec/service-types.html#binding-members-to-properties"
+        "Target Elision Syntax Reference": "https://smithy.io/2.0/spec/idl.html#idl-target-elision"
+    )
+    for: Unit
+
+    /// Mixes in a list of mixins to a shape.
+    @externalDocumentation(
+        "Mixins Reference": "https://smithy.io/2.0/spec/idl.html#mixins"
+    )
+    with: Unit
+}

--- a/src/main/resources/software/amazon/smithy/lsp/language/members.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/members.smithy
@@ -87,6 +87,7 @@ union ShapeMemberTargets {
     intEnum: Unit
 }
 
+@externalDocumentation("Service Reference": "https://smithy.io/2.0/spec/service-types.html#service")
 structure ServiceShape {
     /// Defines the optional version of the service. The version can be provided in any
     /// format (e.g., 2017-02-11, 2.0, etc).
@@ -143,6 +144,7 @@ map Rename {
     value: String
 }
 
+@externalDocumentation("Operation Reference": "https://smithy.io/2.0/spec/service-types.html#operation")
 structure OperationShape {
     /// The input of the operation defined using a shape ID that MUST target a structure.
     /// - Every operation SHOULD define a dedicated input shape marked with the
@@ -165,6 +167,7 @@ structure OperationShape {
     errors: Errors
 }
 
+@externalDocumentation("Resource Reference": "https://smithy.io/2.0/spec/service-types.html#resource")
 structure ResourceShape {
     /// Defines a map of identifier string names to Shape IDs used to identify the resource.
     /// Each shape ID MUST target a string shape.
@@ -247,11 +250,17 @@ map Properties {
     value: AnyMemberTarget
 }
 
+@externalDocumentation("List Reference": "https://smithy.io/2.0/spec/aggregate-types.html#list")
 structure ListShape {
+    /// The shape of the elements in the list.
     member: AnyMemberTarget
 }
 
+@externalDocumentation("Map Reference": "https://smithy.io/2.0/spec/aggregate-types.html#map")
 structure MapShape {
+    /// The string shape of the keys in the map.
     key: AnyString
+
+    /// The shape of the values in the map.
     value: AnyMemberTarget
 }

--- a/src/main/resources/software/amazon/smithy/lsp/language/members.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/members.smithy
@@ -250,17 +250,13 @@ map Properties {
     value: AnyMemberTarget
 }
 
-@externalDocumentation("List Reference": "https://smithy.io/2.0/spec/aggregate-types.html#list")
+// Note: No builtin docs for list/map members, because they could clobber user-defined docs.
+//  We could add some logic to merge them, but I don't think it is worth it.
 structure ListShape {
-    /// The shape of the elements in the list.
     member: AnyMemberTarget
 }
 
-@externalDocumentation("Map Reference": "https://smithy.io/2.0/spec/aggregate-types.html#map")
 structure MapShape {
-    /// The string shape of the keys in the map.
     key: AnyString
-
-    /// The shape of the values in the map.
     value: AnyMemberTarget
 }

--- a/src/main/resources/software/amazon/smithy/lsp/language/members.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/members.smithy
@@ -2,19 +2,127 @@ $version: "2.0"
 
 namespace smithy.lang.server
 
-structure ShapeMemberTargets {
+union ShapeMemberTargets {
+    /// A service is the entry point of an API that aggregates resources and operations together.
+    @externalDocumentation("Service Reference": "https://smithy.io/2.0/spec/service-types.html#service")
     service: ServiceShape
+
+    /// The operation type represents the input, output, and possible errors of an API operation.
+    @externalDocumentation("Operation Reference": "https://smithy.io/2.0/spec/service-types.html#operation")
     operation: OperationShape
+
+    /// Smithy defines a resource as an entity with an identity that has a set of operations.
+    @externalDocumentation("Resource Reference": "https://smithy.io/2.0/spec/service-types.html#resource")
     resource: ResourceShape
+
+    /// The list type represents an ordered homogeneous collection of values.
+    @externalDocumentation("List Reference": "https://smithy.io/2.0/spec/aggregate-types.html#list")
     list: ListShape
+
+    /// The map type represents a map data structure that maps string keys to homogeneous values.
+    @externalDocumentation("Map Reference": "https://smithy.io/2.0/spec/aggregate-types.html#map")
     map: MapShape
+
+    /// The structure type represents a fixed set of named, unordered, heterogeneous values.
+    @externalDocumentation("Structure Reference": "https://smithy.io/2.0/spec/aggregate-types.html#structure")
+    structure: Unit
+
+    /// The union type represents a tagged union data structure that can take on several different, but fixed, types.
+    @externalDocumentation("Union Reference": "https://smithy.io/2.0/spec/aggregate-types.html#union")
+    union: Unit
+
+    /// A blob is uninterpreted binary data.
+    blob: Unit
+
+    /// A boolean is a Boolean value type.
+    boolean: Unit
+
+    /// A string is a UTF-8 encoded string.
+    string: Unit
+
+    /// A byte is an 8-bit signed integer ranging from -128 to 127 (inclusive).
+    byte: Unit
+
+    /// A short is a 16-bit signed integer ranging from -32,768 to 32,767 (inclusive).
+    short: Unit
+
+    /// An integer is a 32-bit signed integer ranging from -2^31 to (2^31)-1 (inclusive).
+    integer: Unit
+
+    /// A long is a 64-bit signed integer ranging from -2^63 to (2^63)-1 (inclusive).
+    long: Unit
+
+    /// A float is a single precision IEEE-754 floating point number.
+    float: Unit
+
+    /// A double is a double precision IEEE-754 floating point number.
+    double: Unit
+
+    /// A bigInteger is an arbitrarily large signed integer.
+    bigInteger: Unit
+
+    /// A bigDecimal is an arbitrary precision signed decimal number.
+    bigDecimal: Unit
+
+    /// A timestamp represents an instant in time in the proleptic Gregorian calendar,
+    /// independent of local times or timezones. Timestamps support an allowable date
+    /// range between midnight January 1, 0001 CE to 23:59:59.999 on December 31, 9999 CE,
+    /// with a temporal resolution of 1 millisecond.
+    @externalDocumentation("Timestamp Reference": "https://smithy.io/2.0/spec/simple-types.html#timestamp")
+    timestamp: Unit
+
+    /// A document represents protocol-agnostic open content that functions as a kind of
+    /// "any" type. Document types are represented by a JSON-like data model and can
+    /// contain UTF-8 strings, arbitrary precision numbers, booleans, nulls, a list of
+    /// these values, and a map of UTF-8 strings to these values.
+    @externalDocumentation("Document Reference": "https://smithy.io/2.0/spec/simple-types.html#document")
+    document: Unit
+
+    /// The enum shape is used to represent a fixed set of one or more string values.
+    @externalDocumentation("Enum Reference": "https://smithy.io/2.0/spec/simple-types.html#enum")
+    enum: Unit
+
+    /// An intEnum is used to represent an enumerated set of one or more integer values.
+    @externalDocumentation("IntEnum Reference": "https://smithy.io/2.0/spec/simple-types.html#intenum")
+    intEnum: Unit
 }
 
 structure ServiceShape {
+    /// Defines the optional version of the service. The version can be provided in any
+    /// format (e.g., 2017-02-11, 2.0, etc).
     version: String
+
+    /// Binds a set of operation shapes to the service. Each element in the given list
+    /// MUST be a valid shape ID that targets an operation shape.
+    @externalDocumentation(
+        "Operations Reference": "https://smithy.io/2.0/spec/service-types.html#service-operations"
+    )
     operations: Operations
+
+    /// Binds a set of resource shapes to the service. Each element in the given list MUST
+    /// be a valid shape ID that targets a resource shape.
+    @externalDocumentation(
+        "Resources Reference": "https://smithy.io/2.0/spec/service-types.html#service-resources"
+    )
     resources: Resources
+
+    /// Defines a list of common errors that every operation bound within the closure of
+    /// the service can return. Each provided shape ID MUST target a structure shape that
+    /// is marked with the error trait.
     errors: Errors
+
+    /// Disambiguates shape name conflicts in the service closure. Map keys are shape IDs
+    /// contained in the service, and map values are the disambiguated shape names to use
+    /// in the context of the service. Each given shape ID MUST reference a shape contained
+    /// in the closure of the service. Each given map value MUST match the smithy:Identifier
+    /// production used for shape IDs. Renaming a shape does not give the shape a new shape ID.
+    /// - No renamed shape name can case-insensitively match any other renamed shape name
+    ///   or the name of a non-renamed shape contained in the service.
+    /// - Member shapes MAY NOT be renamed.
+    /// - Resource and operation shapes MAY NOT be renamed. Renaming shapes is intended for
+    ///   incidental naming conflicts, not for renaming the fundamental concepts of a service.
+    /// - Shapes from other namespaces marked as private MAY be renamed.
+    /// - A rename MUST use a name that is case-sensitively different from the original shape ID name.
     rename: Rename
 }
 
@@ -36,22 +144,96 @@ map Rename {
 }
 
 structure OperationShape {
+    /// The input of the operation defined using a shape ID that MUST target a structure.
+    /// - Every operation SHOULD define a dedicated input shape marked with the
+    ///   input trait. Creating a dedicated input shape ensures that input members
+    ///   can be added in the future if needed.
+    /// - Input defaults to smithy.api#Unit if no input is defined, indicating that
+    ///   the operation has no meaningful input.
     input: AnyMemberTarget
+
+    /// The output of the operation defined using a shape ID that MUST target a structure.
+    /// - Every operation SHOULD define a dedicated output shape marked with the
+    ///   output trait. Creating a dedicated output shape ensures that output members
+    ///   can be added in the future if needed.
+    /// - Output defaults to smithy.api#Unit if no output is defined, indicating that
+    /// the operation has no meaningful output.
     output: AnyMemberTarget
+
+    /// The errors that an operation can return. Each string in the list is a shape ID that
+    /// MUST target a structure shape marked with the error trait.
     errors: Errors
 }
 
 structure ResourceShape {
+    /// Defines a map of identifier string names to Shape IDs used to identify the resource.
+    /// Each shape ID MUST target a string shape.
+    @externalDocumentation(
+        "Identifiers Reference": "https://smithy.io/2.0/spec/service-types.html#resource-identifiers"
+    )
     identifiers: Identifiers
+
+    /// Defines a map of property string names to Shape IDs that enumerate the properties
+    /// of the resource.
+    @externalDocumentation(
+        "Properties Reference": "https://smithy.io/2.0/spec/service-types.html#resource-properties"
+    )
     properties: Properties
+
+    /// Defines the lifecycle operation used to create a resource using one or more
+    /// identifiers created by the service. The value MUST be a valid Shape ID that targets an operation shape.
+    @externalDocumentation(
+        "Create Reference": "https://smithy.io/2.0/spec/service-types.html#create-lifecycle"
+    )
     create: AnyOperation
+
+    /// Defines an idempotent lifecycle operation used to create a resource using identifiers
+    /// provided by the client. The value MUST be a valid Shape ID that targets an operation shape.
+    @externalDocumentation(
+        "Put Reference": "https://smithy.io/2.0/spec/service-types.html#put-lifecycle"
+    )
     put: AnyOperation
+
+    /// Defines the lifecycle operation used to retrieve the resource. The value MUST be
+    /// a valid Shape ID that targets an operation shape.
+    @externalDocumentation(
+        "Read Reference": "https://smithy.io/2.0/spec/service-types.html#read-lifecycle"
+    )
     read: AnyOperation
+
+    /// Defines the lifecycle operation used to update the resource. The value MUST be a
+    /// valid Shape ID that targets an operation shape.
+    @externalDocumentation(
+        "Update Reference": "https://smithy.io/2.0/spec/service-types.html#update-lifecycle"
+    )
     update: AnyOperation
+
+    /// Defines the lifecycle operation used to delete the resource. The value MUST be a
+    /// valid Shape ID that targets an operation shape.
+    @externalDocumentation(
+        "Delete Reference": "https://smithy.io/2.0/spec/service-types.html#delete-lifecycle"
+    )
     delete: AnyOperation
+
+    /// Defines the lifecycle operation used to list resources of this type. The value
+    /// MUST be a valid Shape ID that targets an operation shape.
+    @externalDocumentation(
+        "List Reference": "https://smithy.io/2.0/spec/service-types.html#list-lifecycle"
+    )
     list: AnyOperation
+
+    /// Binds a list of non-lifecycle instance operations to the resource. Each value in
+    /// the list MUST be a valid Shape ID that targets an operation shape.
     operations: Operations
+
+    /// Binds a list of non-lifecycle collection operations to the resource. Each value in
+    /// the list MUST be a valid Shape ID that targets an operation shape.
     collectionOperations: Operations
+
+    /// Binds a list of resources to this resource as a child resource, forming a containment
+    /// relationship. Each value in the list MUST be a valid Shape ID that targets a resource.
+    /// The resources MUST NOT have a cyclical containment hierarchy, and a resource can not
+    /// be bound more than once in the entire closure of a resource or service.
     resources: Resources
 }
 

--- a/src/main/resources/software/amazon/smithy/lsp/language/metadata.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/metadata.smithy
@@ -28,6 +28,7 @@ list SeverityOverrides {
     member: SeverityOverride
 }
 
+@externalDocumentation("Suppressions Reference": "https://smithy.io/2.0/spec/model-validation.html#suppressions")
 structure Suppression {
     /// The hierarchical validation event ID to suppress.
     id: String
@@ -41,6 +42,7 @@ structure Suppression {
     reason: String
 }
 
+@externalDocumentation("Validators Reference": "https://smithy.io/2.0/spec/model-validation.html#validators")
 structure Validator {
     /// The name of the validator to apply. This name is used in implementations to find and configure
     /// the appropriate validator implementation. Validators only take effect if a Smithy processor
@@ -54,7 +56,6 @@ structure Validator {
     /// IDs that contain dots (.) are hierarchical. For example, the ID "Foo.Bar" contains
     /// the ID "Foo". Event ID hierarchies can be leveraged to group validation events and
     /// allow more granular suppressions.
-    @externalDocumentation("Suppressions Reference": "https://smithy.io/2.0/spec/model-validation.html#suppression-definition")
     id: String
 
     /// Provides a custom message to use when emitting validation events. The special `{super}`
@@ -94,6 +95,7 @@ list AnyNamespaces {
     member: AnyNamespace
 }
 
+@externalDocumentation("Severity Overrides Reference": "https://smithy.io/2.0/spec/model-validation.html#severity-overrides")
 structure SeverityOverride {
     /// The hierarchical validation event ID to elevate.
     id: String
@@ -125,6 +127,7 @@ structure BuiltinValidators {
     UnreferencedShapes: UnreferencedShapesConfig
 }
 
+@externalDocumentation("EmitEachSelector Reference": "https://smithy.io/2.0/spec/model-validation.html#emiteachselector")
 structure EmitEachSelectorConfig {
     /// A valid selector. A validation event is emitted for each shape in the model that matches the selector.
     @required
@@ -139,6 +142,7 @@ structure EmitEachSelectorConfig {
     messageTemplate: String
 }
 
+@externalDocumentation("EmitNoneSelector Reference": "https://smithy.io/2.0/spec/model-validation.html#emitnoneselector")
 structure EmitNoneSelectorConfig {
     /// A valid selector. If no shape in the model is returned by the selector, then a validation event is emitted.
     @required

--- a/src/main/resources/software/amazon/smithy/lsp/language/metadata.smithy
+++ b/src/main/resources/software/amazon/smithy/lsp/language/metadata.smithy
@@ -4,15 +4,15 @@ namespace smithy.lang.server
 
 structure BuiltinMetadata {
     /// Suppressions are used to suppress specific validation events.
-    /// See [Suppressions](https://smithy.io/2.0/spec/model-validation.html#suppressions)
+    @externalDocumentation("Suppressions Reference": "https://smithy.io/2.0/spec/model-validation.html#suppressions")
     suppressions: Suppressions
 
     /// An array of validator objects used to constrain the model.
-    /// See [Validators](https://smithy.io/2.0/spec/model-validation.html#validators)
+    @externalDocumentation("Validators Reference": "https://smithy.io/2.0/spec/model-validation.html#validators")
     validators: Validators
 
     /// An array of severity override objects used to raise the severity of non-suppressed validation events.
-    /// See [Severity overrides](https://smithy.io/2.0/spec/model-validation.html#severity-overrides)
+    @externalDocumentation("Severity Overrides Reference": "https://smithy.io/2.0/spec/model-validation.html#severity-overrides")
     severityOverrides: SeverityOverrides
 }
 
@@ -42,12 +42,45 @@ structure Suppression {
 }
 
 structure Validator {
+    /// The name of the validator to apply. This name is used in implementations to find and configure
+    /// the appropriate validator implementation. Validators only take effect if a Smithy processor
+    /// implements the validator.
     name: ValidatorName
+
+    /// Defines a custom identifier for the validator.
+    /// Multiple instances of a single validator can be configured for a model. Providing
+    /// an `id` allows suppressions to suppress a specific instance of a validator.
+    /// If `id` is not specified, it will default to the name property of the validator definition.
+    /// IDs that contain dots (.) are hierarchical. For example, the ID "Foo.Bar" contains
+    /// the ID "Foo". Event ID hierarchies can be leveraged to group validation events and
+    /// allow more granular suppressions.
+    @externalDocumentation("Suppressions Reference": "https://smithy.io/2.0/spec/model-validation.html#suppression-definition")
     id: String
+
+    /// Provides a custom message to use when emitting validation events. The special `{super}`
+    /// string can be added to a custom message to inject the original error message of
+    /// the validation event into the custom message.
     message: String
+
+    /// Provides a custom severity level to use when a validation event occurs. If no severity
+    /// is provided, then the default severity of the validator is used.
+    ///
+    /// **Note** The severity of user-defined validators cannot be set to `ERROR`.
+    @externalDocumentation("Severity Reference": "https://smithy.io/2.0/spec/model-validation.html#severity-definition")
     severity: ValidatorSeverity
+
+    /// Provides a list of the namespaces that are targeted by the validator. The validator
+    /// will ignore any validation events encountered that are not specific to the given namespaces.
     namespaces: AnyNamespaces
+
+    /// A valid selector that causes the validator to only validate shapes that match the
+    /// selector. The validator will ignore any validation events encountered that do not
+    /// satisfy the selector.
+    @externalDocumentation("Selector Reference": "https://smithy.io/2.0/spec/selectors.html#selectors")
     selector: String
+
+    /// Object that provides validator configuration. The available properties are defined
+    /// by each validator. Validators MAY require that specific configuration properties are provided.
     configuration: ValidatorConfig
 }
 
@@ -62,8 +95,16 @@ list AnyNamespaces {
 }
 
 structure SeverityOverride {
+    /// The hierarchical validation event ID to elevate.
     id: String
+
+    /// The validation event is only elevated if it matches the supplied namespace.
+    /// A value of `*` can be provided to match any namespace.
     namespace: AnyNamespace
+
+    /// Defines the severity to elevate matching events to. This value can only be set
+    /// to `WARNING` or `DANGER`.
+    @externalDocumentation("Severity Reference": "https://smithy.io/2.0/spec/model-validation.html#severity-definition")
     severity: SeverityOverrideSeverity
 }
 
@@ -73,19 +114,33 @@ enum SeverityOverrideSeverity {
 }
 
 structure BuiltinValidators {
+    /// Emits a validation event for each shape that matches the given selector.
+    @externalDocumentation("EmitEachSelector Reference": "https://smithy.io/2.0/spec/model-validation.html#emiteachselector")
     EmitEachSelector: EmitEachSelectorConfig
+
+    /// Emits a validation event if no shape in the model matches the given selector.
+    @externalDocumentation("EmitNoneSelector Reference": "https://smithy.io/2.0/spec/model-validation.html#emitnoneselector")
     EmitNoneSelector: EmitNoneSelectorConfig
+
     UnreferencedShapes: UnreferencedShapesConfig
 }
 
 structure EmitEachSelectorConfig {
+    /// A valid selector. A validation event is emitted for each shape in the model that matches the selector.
     @required
     selector: Selector
+
+    /// An optional string that MUST be a valid shape ID that targets a trait definition.
+    /// A validation event is only emitted for shapes that have this trait.
     bindToTrait: AnyTrait
+
+    /// A custom template that is expanded for each matching shape and assigned as the message
+    /// for the emitted validation event.
     messageTemplate: String
 }
 
 structure EmitNoneSelectorConfig {
+    /// A valid selector. If no shape in the model is returned by the selector, then a validation event is emitted.
     @required
     selector: Selector
 }

--- a/src/test/java/software/amazon/smithy/lsp/language/BuildHoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/BuildHoverHandlerTest.java
@@ -75,6 +75,18 @@ public class BuildHoverHandlerTest {
         assertThat(hovers, empty());
     }
 
+    @Test
+    public void membersIncludeInheritedDocs() {
+        var twp = TextWithPositions.from("""
+                %{
+                    %"version": "1.0"
+                }
+                """);
+        var hovers = getHovers(BuildFileType.SMITHY_BUILD, twp);
+
+        assertThat(hovers, contains(containsString("Smithy Build Reference")));
+    }
+
     private static List<String> getHovers(BuildFileType buildFileType, TextWithPositions twp) {
         var workspace = TestWorkspace.emptyWithNoConfig("test");
         workspace.addModel(buildFileType.filename(), twp.text());

--- a/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
@@ -303,6 +303,41 @@ public class HoverHandlerTest {
         ));
     }
 
+    @Test
+    public void builtinHoverDoesntClobberUserDocs() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                list Foo {
+                    /// One
+                    %member: String
+                }
+                
+                map Bar {
+                    /// Two
+                    %key: String
+                
+                    /// Three
+                    %value: String
+                }
+                
+                structure Baz {
+                    /// Four
+                    /// Five
+                    %baz: String
+                }
+                """);
+        var hovers = getHovers(twp);
+
+        assertThat(hovers, contains(
+                containsString("One"),
+                containsString("Two"),
+                containsString("Three"),
+                containsString("Four")
+        ));
+    }
+
     private static List<String> getHovers(TextWithPositions text) {
         return getHovers(text.text(), text.positions());
     }

--- a/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
@@ -148,7 +148,7 @@ public class HoverHandlerTest {
     }
 
     @Test
-    public void keywordHover() {
+    public void shapeKeywordHover() {
         var twp = TextWithPositions.from("""
                 $version: "2"
                 namespace com.foo
@@ -168,7 +168,6 @@ public class HoverHandlerTest {
                 """);
         var hovers = getHovers(twp);
         assertThat(hovers, contains(
-//                containsString("Namespace"),
                 containsString("Service Reference"),
                 containsString("Operation Reference"),
                 containsString("Resource Reference"),
@@ -247,6 +246,60 @@ public class HoverHandlerTest {
                 containsString("instance operations"),
                 containsString("collection operations"),
                 containsString("child resource")
+        ));
+    }
+
+    @Test
+    public void nonShapeKeywordHover() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                
+                %metadata foo = "foo"
+                
+                %namespace com.foo
+                
+                %use com.foo#Foo
+                
+                %apply Foo @bar
+                
+                structure Foo %for Bar {}
+                
+                structure Baz %with [Foo] {}
+                """);
+        var hovers = getHovers(twp);
+
+        assertThat(hovers, contains(
+                containsString("schema-less"),
+                containsString("A namespace is"),
+                containsString("The use section"),
+                containsString("Applies a trait"),
+                containsString("Allows referencing"),
+                containsString("Mixes in")
+        ));
+    }
+
+    @Test
+    public void builtinsHoverIncludeInheritedDocs() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                
+                metadata validators = [
+                    {
+                        %name: ""
+                    }
+                ]
+                
+                namespace com.foo
+                
+                operation MyOperation {
+                    %input := {}
+                }
+                """);
+        var hovers = getHovers(twp);
+
+        assertThat(hovers, contains(
+                containsString("Validators Reference"),
+                containsString("Operation Reference")
         ));
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
@@ -42,7 +42,7 @@ public class HoverHandlerTest {
                 """);
         List<String> hovers = getHovers(text, new Position(0, 9));
 
-        assertThat(hovers, contains(containsString("suppressions")));
+        assertThat(hovers, contains(containsString("Suppressions")));
     }
 
     @Test
@@ -145,6 +145,43 @@ public class HoverHandlerTest {
         List<String> hovers = getHovers(text);
 
         assertThat(hovers, contains(containsString("bar: String")));
+    }
+
+    @Test
+    public void keywordHover() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                %namespace com.foo
+                
+                %service MyService {}
+                %operation MyOperation {}
+                %resource MyResource {}
+                %list MyList {}
+                %map MyMap {}
+                %structure MyStructure {}
+                %union MyUnion {}
+                %blob MyBlob
+                %timestamp MyTimestamp
+                %document MyDocument
+                %enum MyEnum {}
+                %intEnum MyIntEnum {}
+                """);
+        var hovers = getHovers(twp);
+        assertThat(hovers, contains(
+                containsString("Namespace"),
+                containsString("Service Reference"),
+                containsString("Operation Reference"),
+                containsString("Resource Reference"),
+                containsString("List Reference"),
+                containsString("Map Reference"),
+                containsString("Structure Reference"),
+                containsString("Union Reference"),
+                containsString("binary data"),
+                containsString("Timestamp Reference"),
+                containsString("Document Reference"),
+                containsString("Enum Reference"),
+                containsString("IntEnum Reference")
+        ));
     }
 
     private static List<String> getHovers(TextWithPositions text) {

--- a/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
@@ -151,7 +151,7 @@ public class HoverHandlerTest {
     public void keywordHover() {
         var twp = TextWithPositions.from("""
                 $version: "2"
-                %namespace com.foo
+                namespace com.foo
                 
                 %service MyService {}
                 %operation MyOperation {}
@@ -168,7 +168,7 @@ public class HoverHandlerTest {
                 """);
         var hovers = getHovers(twp);
         assertThat(hovers, contains(
-                containsString("Namespace"),
+//                containsString("Namespace"),
                 containsString("Service Reference"),
                 containsString("Operation Reference"),
                 containsString("Resource Reference"),
@@ -181,6 +181,72 @@ public class HoverHandlerTest {
                 containsString("Document Reference"),
                 containsString("Enum Reference"),
                 containsString("IntEnum Reference")
+        ));
+    }
+
+    @Test
+    public void builtinMemberHover() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                service MyService {
+                    %version: ""
+                    %operations: []
+                    %resources: []
+                    %errors: []
+                    %rename: {}
+                }
+                
+                operation MyOperation {
+                    %input := {}
+                    %output := {}
+                    %errors: []
+                }
+                
+                operation NoInlineOperation {
+                    %input: Foo
+                    %output: Foo
+                    %errors: []
+                }
+                
+                resource MyResource {
+                    %identifiers: {}
+                    %properties: {}
+                    %create: {}
+                    %put: {}
+                    %read: {}
+                    %update: {}
+                    %delete: {}
+                    %list: {}
+                    %operations: []
+                    %collectionOperations: []
+                    %resources: []
+                }
+                """);
+        var hovers = getHovers(twp);
+        assertThat(hovers, contains(
+                containsString("optional version"),
+                containsString("operation shapes"),
+                containsString("resource shapes"),
+                containsString("common errors"),
+                containsString("Disambiguates"),
+                containsString("input of the operation"),
+                containsString("output of the operation"),
+                containsString("errors that an operation"),
+                containsString("input of the operation"),
+                containsString("output of the operation"),
+                containsString("errors that an operation"),
+                containsString("map of identifier"),
+                containsString("map of property"),
+                containsString("create a resource"),
+                containsString("idempotent"),
+                containsString("retrieve the resource"),
+                containsString("update the resource"),
+                containsString("delete the resource"),
+                containsString("list resources"),
+                containsString("instance operations"),
+                containsString("collection operations"),
+                containsString("child resource")
         ));
     }
 


### PR DESCRIPTION
This adds hover info for a bunch of things that I didn't get around to in the initial hover upgrade,
including:
- All shape types
- Non shape type keywords, `metadata`, `namespace`, `use`, `apply`, `with`, and `for`
- Member names in service, resource, and operation shapes
- Links to Smithy docs site for all these "builtins"
- Documentation traits on user-defined members (before it just wasn't rendered)

I had to add new builtin model for the non-shape keywords, but reused `ShapeMemberTargets` for
shape type keyword hover.

I also had to add a way to check if the cursor was inside the keyword of a statement, which simplifies
IdlPosition a bit too.

The Smithy docs links use `externalDocumentation`, like the smithy-build.json model, and I also added
a way to include docs links to all members of a builtin shape, because there's some things which don't
have a great link for themselves specifically, but it would still be nice to allow navigating to _some_
docs page that could be useful. This works by adding the `externalDocumentation` trait to the root
shape in the builtins model, and having the hover implementation add any external docs from the
container shape when constructing hover for a builtin. So, for example, hovering over `"version": "1.0"`
in smithy-build.json now also includes a link to the smithy-build.json page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
