### PR TITLE
Fix idRef completions

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/language/CompletionHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/CompletionHandler.java
@@ -175,8 +175,14 @@ public final class CompletionHandler {
     ) {
         var result = ShapeSearch.searchTraitValue(traitValue, model);
         Set<String> excludeKeys = result.getOtherPresentKeys();
+        var contextWithExclude = context.withExclude(excludeKeys);
+
         CompletionCandidates candidates = CompletionCandidates.fromSearchResult(result);
-        return new SimpleCompleter(context.withExclude(excludeKeys)).getCompletionItems(candidates);
+        if (candidates instanceof CompletionCandidates.Shapes shapes) {
+            return new ShapeCompleter(traitValue, model, contextWithExclude).getCompletionItems(shapes);
+        }
+
+        return new SimpleCompleter(contextWithExclude).getCompletionItems(candidates);
     }
 
     private List<CompletionItem> memberNameCompletions(IdlPosition.MemberName memberName, CompleterContext context) {

--- a/src/main/java/software/amazon/smithy/lsp/language/HoverHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/HoverHandler.java
@@ -30,7 +30,6 @@ import software.amazon.smithy.model.shapes.SmithyIdlModelSerializer;
 import software.amazon.smithy.model.shapes.StructureShape;
 import software.amazon.smithy.model.traits.DocumentationTrait;
 import software.amazon.smithy.model.traits.ExternalDocumentationTrait;
-import software.amazon.smithy.model.traits.IdRefTrait;
 import software.amazon.smithy.model.validation.Severity;
 import software.amazon.smithy.model.validation.ValidatedResult;
 import software.amazon.smithy.model.validation.ValidationEvent;
@@ -108,8 +107,8 @@ public final class HoverHandler {
 
     private static Optional<? extends Shape> takeShapeReference(NodeSearch.Result result) {
         return switch (result) {
-            case NodeSearch.Result.TerminalShape(Shape shape, var ignored)
-                    when shape.hasTrait(IdRefTrait.class) -> Optional.of(shape);
+            case NodeSearch.Result.TerminalShape terminalShape
+                    when terminalShape.isIdRef() -> Optional.of(terminalShape.shape());
 
             case NodeSearch.Result.ObjectKey(NodeCursor.Key key, Shape containerShape, var ignored)
                     when !containerShape.isMapShape() -> containerShape.getMember(key.name());

--- a/src/test/java/software/amazon/smithy/lsp/language/CompletionHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/CompletionHandlerTest.java
@@ -1075,6 +1075,40 @@ public class CompletionHandlerTest {
         assertThat(item.getAdditionalTextEdits(), nullValue());
     }
 
+    @Test
+    public void completesIdRefs() {
+        TextWithPositions text = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                @trait
+                structure myId {
+                    ref: ShapeId
+                }
+                @idRef
+                string ShapeId
+                @myId(ref: %)
+                """);
+        List<String> comps = getCompLabels(text);
+
+        assertThat(comps, hasItems("myId", "ShapeId"));
+    }
+
+    @Test
+    public void completesIdRefsOnMember() {
+        TextWithPositions text = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                @trait
+                structure myId {
+                    @idRef
+                    ref: String
+                }
+                @myId(ref: %)
+                """);
+        List<String> comps = getCompLabels(text);
+        assertThat(comps, hasItems("myId", "String"));
+    }
+
     private static List<String> getCompLabels(TextWithPositions textWithPositions) {
         return getCompLabels(textWithPositions.text(), textWithPositions.positions());
     }

--- a/src/test/java/software/amazon/smithy/lsp/language/DefinitionHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/DefinitionHandlerTest.java
@@ -313,6 +313,27 @@ public class DefinitionHandlerTest {
     }
 
     @Test
+    public void idRefMemberTraitValue() {
+        TextWithPositions text = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure foo {
+                    @idRef
+                    id: String
+                }
+                
+                @foo(id: %Bar)
+                string Bar
+                """);
+        GetLocationsResult result = getLocations(text);
+        assertThat(result.locations, hasSize(1));
+        assertThat(result.locations.getFirst().getUri(), endsWith("main.smithy"));
+        assertIsShapeDef(result, result.locations.getFirst(), "string Bar");
+    }
+
+    @Test
     public void absoluteShapeId() {
         TextWithPositions text = TextWithPositions.from("""
                 $version: "2"

--- a/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
@@ -7,6 +7,7 @@ package software.amazon.smithy.lsp.language;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static software.amazon.smithy.lsp.document.DocumentTest.safeString;
 
@@ -335,6 +336,28 @@ public class HoverHandlerTest {
                 containsString("Two"),
                 containsString("Three"),
                 containsString("Four")
+        ));
+    }
+
+    @Test
+    public void idRefMemberTraitValue() {
+        TextWithPositions text = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure foo {
+                    @idRef
+                    id: String
+                }
+                
+                @foo(id: %Bar)
+                string Bar
+                """);
+        var hovers = getHovers(text);
+
+        assertThat(hovers, containsInAnyOrder(
+                containsString("string Bar")
         ));
     }
 


### PR DESCRIPTION
The original implementation didn't check members for the idRef trait, and in general didn't handle idRefs in trait values. This commit fixes both of those issues by adding a `targetOf` field to TerminalShape, so that member can be checked for the idRef trait, and uses ShapeCompleter when a trait value completion is for an idRef.

I also added some extra tests for definition and hover to make sure it was working correctly there too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
