### PR TITLE
Change source location none comparison

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/project/Project.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/Project.java
@@ -554,7 +554,7 @@ public final class Project {
         }
 
         private static boolean isNone(SourceLocation sourceLocation) {
-            return sourceLocation.equals(SourceLocation.NONE);
+            return sourceLocation.getFilename().equals(SourceLocation.NONE.getFilename());
         }
     }
 }


### PR DESCRIPTION
RebuildIndex checks the source location of traits to see if they are SourceLocation.NONE when determining which files depend on eachother. SourceLocation's equals does a toString to compare though, which is unnecessarily slow, so I changed our comparison to just check the filename.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
