### PR TITLE
Expand tests on parser to acheive higher coverage and minor fixs

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
@@ -55,7 +55,7 @@ final class Parser extends SimpleParser {
                 int start = position();
                 do {
                     skip();
-                } while (!isWs() && !isNodeStructuralBreakpoint() && !eof());
+                } while (!isWs() && !isNodeStructuralBreakpoint() && !eof() && is(','));
                 int end = position();
                 Syntax.Node.Err err = new Syntax.Node.Err("unexpected token " + document.copySpan(start, end));
                 err.start = start;
@@ -306,7 +306,9 @@ final class Parser extends SimpleParser {
             if (err != null) {
                 addError(err);
             }
-
+            if (kvp != null) {
+                setEnd(kvp);
+            }
             return nodeErr("expected value");
         }
 
@@ -815,7 +817,6 @@ final class Parser extends SimpleParser {
                 addErr(position(), position(), "expected :");
                 if (isWs() || is('}')) {
                     setEnd(memberDef);
-                    addStatement(memberDef);
                     return;
                 }
             }
@@ -968,10 +969,6 @@ final class Parser extends SimpleParser {
         } while (isIdentChar());
 
         int end = position();
-        if (start == end) {
-            addErr(start, end, "expected identifier");
-            return Syntax.Ident.EMPTY;
-        }
         return new Syntax.Ident(start, end, document.copySpan(start, end));
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
@@ -889,11 +889,11 @@ public class IdlParserTest {
             new InvalidSyntaxTestCase(
                     "regular shape missing assignment",
                     """
-                            structure Foo {
-                                foo
-                                bar
-                            }
-                            """,
+                    structure Foo {
+                        foo
+                        bar
+                    }
+                    """,
                     List.of("expected :","expected :"),
                     List.of(Syntax.Statement.Type.ShapeDef, Syntax.Statement.Type.Block, Syntax.Statement.Type.MemberDef, Syntax.Statement.Type.MemberDef)
             ),
@@ -955,11 +955,11 @@ public class IdlParserTest {
             ),
             new InvalidSyntaxTestCase(
                     "node shape missing assignment",
-                            """
-                            service Foo{
-                                a
-                                b
-                            }
+                    """
+                    service Foo{
+                        a
+                        b
+                    }
                     """,
                     List.of("expected :", "expected :"),
                     List.of(Syntax.Statement.Type.ShapeDef, Syntax.Statement.Type.Block, Syntax.Statement.Type.NodeMemberDef, Syntax.Statement.Type.NodeMemberDef)
@@ -1000,7 +1000,8 @@ public class IdlParserTest {
                             {
                             foo:\s
                             }
-                    }""",
+                    }
+                    """,
                     List.of("expected identifier"),
                     List.of(
                             Syntax.Statement.Type.ShapeDef,
@@ -1049,7 +1050,8 @@ public class IdlParserTest {
                     operation Op {
                         input
                         output
-                    }""",
+                    }
+                    """,
                     List.of("expected :", "expected :"),
                     List.of(
                             Syntax.Statement.Type.ShapeDef,
@@ -1060,7 +1062,7 @@ public class IdlParserTest {
             new InvalidSyntaxTestCase(
                     "trait use unexpected key",
                     """
-                            @integration(String:
+                    @integration(String:
                     """,
                     List.of("unexpected token "),
                     List.of(
@@ -1069,9 +1071,9 @@ public class IdlParserTest {
             new InvalidSyntaxTestCase(
                     "control without value",
                     """
-                            $version
-                            $operationInputSuffix "Request"
-                            $operationInputSuffix: "Request"
+                    $version
+                    $operationInputSuffix "Request"
+                    $operationInputSuffix: "Request"
                     """,
                     List.of("expected :", "expected :"),
                     List.of(
@@ -1082,8 +1084,8 @@ public class IdlParserTest {
             new InvalidSyntaxTestCase(
                     "metadata without equal",
                     """
-                            metadata bar
-                            structure foo{}
+                    metadata bar
+                    structure foo{}
                     """,
                     List.of("expected ="),
                     List.of(

--- a/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
@@ -859,7 +859,7 @@ public class IdlParserTest {
             new InvalidSyntaxTestCase(
                     "enum using invalid value",
                     "enum Foo {?}",
-                    List.of("unexpected token ? expected trait or member"),
+                    List.of("unexpected token ? expected trait or member", "expected member or trait"),
                     List.of(Syntax.Statement.Type.ShapeDef, Syntax.Statement.Type.Block)
             ),
             new InvalidSyntaxTestCase(
@@ -900,7 +900,7 @@ public class IdlParserTest {
             new InvalidSyntaxTestCase(
                     "regular shape with invalid member",
                     "structure Foo {?}",
-                    List.of("unexpected token ? expected trait or member"),
+                    List.of("unexpected token ? expected trait or member", "expected member or trait"),
                     List.of(Syntax.Statement.Type.ShapeDef, Syntax.Statement.Type.Block)
             ),
             new InvalidSyntaxTestCase(

--- a/src/test/java/software/amazon/smithy/lsp/syntax/NodeParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/NodeParserTest.java
@@ -20,7 +20,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.lsp.document.Document;
-import software.amazon.smithy.syntax.shaded.prettier4j.Doc;
 
 public class NodeParserTest {
     @Test

--- a/src/test/java/software/amazon/smithy/lsp/syntax/NodeParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/NodeParserTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import software.amazon.smithy.lsp.document.Document;
+import software.amazon.smithy.syntax.shaded.prettier4j.Doc;
 
 public class NodeParserTest {
     @Test
@@ -83,6 +84,21 @@ public class NodeParserTest {
                 Syntax.Node.Type.Kvp,
                 Syntax.Node.Type.Str,
                 Syntax.Node.Type.Str,
+                Syntax.Node.Type.Kvp,
+                Syntax.Node.Type.Str,
+                Syntax.Node.Type.Str);
+    }
+    @Test
+    public void goodObjSingleKeyWithTrailingComma() {
+        String text = """
+                {"a":{"abc": "def"} , }""";
+        assertTypesEqual(text,
+                Syntax.Node.Type.Obj,
+                Syntax.Node.Type.Kvps,
+                Syntax.Node.Type.Kvp,
+                Syntax.Node.Type.Str,
+                Syntax.Node.Type.Obj,
+                Syntax.Node.Type.Kvps,
                 Syntax.Node.Type.Kvp,
                 Syntax.Node.Type.Str,
                 Syntax.Node.Type.Str);
@@ -321,6 +337,14 @@ public class NodeParserTest {
                     List.of(Syntax.Node.Type.Obj, Syntax.Node.Type.Kvps, Syntax.Node.Type.Kvp, Syntax.Node.Type.Str)
             ),
             new InvalidSyntaxTestCase(
+                    "String key with : but no }",
+                    "{\"1\": abc, \"2\": def",
+                    List.of("missing }"),
+                    List.of(Syntax.Node.Type.Obj, Syntax.Node.Type.Kvps, Syntax.Node.Type.Kvp,
+                            Syntax.Node.Type.Str, Syntax.Node.Type.Ident, Syntax.Node.Type.Kvp,
+                            Syntax.Node.Type.Str, Syntax.Node.Type.Ident)
+            ),
+            new InvalidSyntaxTestCase(
                     "Invalid key",
                     "{\"abc}",
                     List.of("unexpected eof", "missing }"),
@@ -331,6 +355,34 @@ public class NodeParserTest {
                     "{\"abc\" 1}",
                     List.of("expected :"),
                     List.of(Syntax.Node.Type.Obj, Syntax.Node.Type.Kvps, Syntax.Node.Type.Kvp, Syntax.Node.Type.Str)
+            ),
+            new InvalidSyntaxTestCase(
+                    "Missing key in obj",
+                            "{,}",
+                    List.of(),
+                    List.of(Syntax.Node.Type.Obj, Syntax.Node.Type.Kvps)
+            ),
+            new InvalidSyntaxTestCase(
+                    "Missing colon and unexpected value in obj",
+                    "{foo ?}",
+                    List.of("expected :","unexpected token ?"),
+                    List.of(Syntax.Node.Type.Obj, Syntax.Node.Type.Kvps, Syntax.Node.Type.Kvp, Syntax.Node.Type.Ident)
+            ),
+            new InvalidSyntaxTestCase(
+                    "Unclosed text block",
+                    """
+                            \"\"\"abc
+                            """,
+                    List.of(),
+                    List.of(Syntax.Node.Type.Err)
+            ),
+            new InvalidSyntaxTestCase(
+                    "Invalid number",
+                    """
+                           123?
+                            """,
+                    List.of(),
+                    List.of(Syntax.Node.Type.Err)
             )
     );
 
@@ -392,6 +444,48 @@ public class NodeParserTest {
         Syntax.Node third = arr.elements().get(2);
         assertThat(third, instanceOf(Syntax.Node.Str.class));
         assertThat(((Syntax.Node.Str) third).stringValue().trim(), equalTo("foo"));
+    }
+
+    @Test
+    public void badKvpWithTrailingIncompleteKvp() {
+        String text = "{\"foo\":bar, \"buz\"}";
+        Document document = Document.of(text);
+        Syntax.Node.Obj node = (Syntax.Node.Obj)Syntax.parseNode(document).value();
+        Syntax.Node.Kvps kvps = node.kvps();
+        assertThat(document.copySpan(kvps.start, kvps.end), equalTo("{\"foo\":bar, \"buz\"}"));
+        Syntax.Node.Kvp first = kvps.kvps().get(0);
+        assertThat(document.copySpan(first.start, first.end), equalTo("\"foo\":bar"));
+        Syntax.Node.Kvp second = kvps.kvps().get(1);
+        assertThat(document.copySpan(second.start, second.end), equalTo("\"buz\""));
+    }
+
+    @Test
+    public void badKvpWithLeadingComma() {
+        String text = "{,\"foo\":bar}";
+        Document document = Document.of(text);
+        Syntax.Node.Obj node = (Syntax.Node.Obj)Syntax.parseNode(document).value();
+        Syntax.Node.Kvps kvps = node.kvps();
+        assertThat(document.copySpan(kvps.start, kvps.end), equalTo("{,\"foo\":bar}"));
+        Syntax.Node.Kvp first = kvps.kvps().get(0);
+        assertThat(document.copySpan(first.start, first.end), equalTo("\"foo\":bar"));
+    }
+
+    @Test
+    public void badArrWithLeadingComma() {
+        String text = "[,a,";
+        Document document = Document.of(text);
+        Syntax.Node.Arr arr = (Syntax.Node.Arr)Syntax.parseNode(document).value();
+        assertThat(arr.elements(), hasSize(1));
+        assertThat(document.copySpan(arr.elements.get(0).start, arr.elements.get(0).end), equalTo("a"));
+    }
+
+    @Test
+    public void badArrWithInvalidNum() {
+        String text = "[456?,123]";
+        Document document = Document.of(text);
+        Syntax.Node.Arr arr = (Syntax.Node.Arr)Syntax.parseNode(document).value();
+        assertThat(arr.elements(), hasSize(1));
+        assertThat(document.copySpan(arr.elements.get(0).start, arr.elements.get(0).end), equalTo("123"));
     }
 
     private static void assertTypesEqual(String text, Syntax.Node.Type... types) {


### PR DESCRIPTION
*Description of changes:*
Expand tests on parser to acheive a coverage of 98% in Line and 88% in branch. 
Add fix for Node with leading comma.
Add fix for duplicate statement when invalid member def statement appears.
Add fix for unset end of kvp.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
