### PR TITLE
Implement references and rename

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/document/Document.java
+++ b/src/main/java/software/amazon/smithy/lsp/document/Document.java
@@ -217,7 +217,7 @@ public final class Document {
      * @return The range of the token, excluding enclosing ""
      */
     public Range rangeOfValue(Syntax.Node.Str token) {
-        int lineStart = indexOfLine(token.line());
+        int lineStart = indexOfLine(token.lineNumber());
         if (lineStart < 0) {
             return null;
         }
@@ -230,7 +230,7 @@ public final class Document {
             endChar -= 1;
         }
 
-        return new Range(new Position(token.line(), startChar), new Position(token.line(), endChar));
+        return new Range(new Position(token.lineNumber(), startChar), new Position(token.lineNumber(), endChar));
     }
 
     /**

--- a/src/main/java/software/amazon/smithy/lsp/document/DocumentId.java
+++ b/src/main/java/software/amazon/smithy/lsp/document/DocumentId.java
@@ -23,29 +23,17 @@ public record DocumentId(Type type, CharBuffer idSlice, Range range) {
      */
     public enum Type {
         /**
-         * Just a shape name, no namespace or member.
+         * A root shape id, i.e. without trailing '$member'. May or may not
+         * have a leading namespace.
          */
-        ID,
+        ROOT,
 
         /**
-         * Same as {@link Type#ID}, but with a namespace.
+         * A shape id with a member, i.e. with trailing '$member'. May or may
+         * not have a leading namespace. May or may not have a root shape name
+         * before the '$member'.
          */
-        ABSOLUTE_ID,
-
-        /**
-         * Just a namespace - will have one or more {@code .}.
-         */
-        NAMESPACE,
-
-        /**
-         * Same as {@link Type#ABSOLUTE_ID}, but with a member - will have a {@code $}.
-         */
-        ABSOLUTE_WITH_MEMBER,
-
-        /**
-         * Same as {@link Type#ID}, but with a member - will have a {@code $}.
-         */
-        RELATIVE_WITH_MEMBER
+        MEMBER
     }
 
     public String copyIdValue() {

--- a/src/main/java/software/amazon/smithy/lsp/language/Builtins.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/Builtins.java
@@ -65,6 +65,8 @@ final class Builtins {
                     MemberShape::getMemberName,
                     memberShape -> memberShape.getTarget()));
 
+    static final ShapeId SERVICE_RENAME_ID = id("Rename");
+
     private Builtins() {
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/language/References.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/References.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import software.amazon.smithy.lsp.project.IdlFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.project.SmithyFile;
+import software.amazon.smithy.lsp.protocol.LspAdapter;
+import software.amazon.smithy.lsp.syntax.StatementView;
+import software.amazon.smithy.lsp.syntax.Syntax;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.ListShape;
+import software.amazon.smithy.model.shapes.MapShape;
+import software.amazon.smithy.model.shapes.MemberShape;
+import software.amazon.smithy.model.shapes.Shape;
+import software.amazon.smithy.model.traits.IdRefTrait;
+
+/**
+ * Collects references to a shape across a project or within a specific file.
+ */
+final class References {
+    private final Model model;
+    private final Shape shape;
+    private final ShapeReferencesNodeWalker traitValueWalker;
+    private final ShapeReferencesNodeWalker nodeMemberWalker;
+    private final List<FileReferences> fileReferences = new ArrayList<>();
+    private final List<DefinitionReference> definitionReferences = new ArrayList<>();
+    private List<Syntax.Statement.Use> pendingUseRefs = new ArrayList<>();
+    private List<Syntax.Node.Str> pendingRefs = new ArrayList<>();
+    private IdlFile currentFile;
+    private Syntax.IdlParseResult currentParseResult;
+
+    private References(Model model, Shape shape) {
+        this.model = model;
+        this.shape = shape;
+        this.traitValueWalker = new ShapeReferencesNodeWalker(model, this);
+        this.nodeMemberWalker = new ShapeReferencesNodeWalker(Builtins.MODEL, this);
+    }
+
+    /**
+     * References to a shape in a specific file, excluding the shape's definition.
+     *
+     * @param idlFile The file the references are in
+     * @param useRefs The references in use statements
+     * @param refs All other references in the file
+     */
+    record FileReferences(IdlFile idlFile, List<Syntax.Statement.Use> useRefs, List<Syntax.Node.Str> refs) {}
+
+    /**
+     * The definition of a shape.
+     *
+     * @param idlFile The file the shape is defined in
+     * @param ref The shape's name token
+     */
+    record DefinitionReference(IdlFile idlFile, Syntax.Node.Str ref) {}
+
+    /**
+     * Finds all references to {@code shape} across all files in the given {@code project}.
+     *
+     * @param model The model the shape is in
+     * @param shape The shape to find references to
+     * @param project The project to find references in
+     * @return All found references, including the shape's definition
+     */
+    static References findReferences(Model model, Shape shape, Project project) {
+        var references = new References(model, shape);
+        references.findReferences(project);
+        return references;
+    }
+
+    /**
+     * Finds all references to {@code shape} in the given {@code idlFile}.
+     *
+     * @param model The model the shape is in
+     * @param shape The shape to find references to
+     * @param idlFile The file to find references in
+     * @return All found references, not including the shape's definition
+     */
+    static References findReferences(Model model, Shape shape, IdlFile idlFile) {
+        var references = new References(model, shape);
+        references.findReferences(idlFile);
+        return references;
+    }
+
+    /**
+     * @return A list of all found references
+     */
+    List<FileReferences> fileReferences() {
+        return fileReferences;
+    }
+
+    /**
+     * @return A list of all found definitions
+     */
+    List<DefinitionReference> definitionReferences() {
+        return definitionReferences;
+    }
+
+    private void addPendingReferences() {
+        // Don't create a new FileReferences when there weren't any refs in
+        // the file.
+        if (!pendingUseRefs.isEmpty() || !pendingRefs.isEmpty()) {
+            fileReferences.add(new FileReferences(
+                    currentFile,
+                    pendingUseRefs,
+                    pendingRefs
+            ));
+
+            // Create a fresh pending list so subsequent modifications don't mutate a
+            // list in the FileReferences we just made.
+            pendingUseRefs = new ArrayList<>();
+            pendingRefs = new ArrayList<>();
+        }
+    }
+
+    private void findReferences(Project project) {
+        for (SmithyFile smithyFile : project.getAllSmithyFiles()) {
+            if (!(smithyFile instanceof IdlFile idlFile)) {
+                continue;
+            }
+
+            findReferences(idlFile);
+        }
+
+        // Include the shape's definition, which won't be collected otherwise.
+        // Note: This doesn't add the definition of an inline shape, because it
+        //  doesn't have an identifier to ref.
+        addDefinitionReference(project);
+    }
+
+    private void findReferences(IdlFile idlFile) {
+        currentFile = idlFile;
+        currentParseResult = idlFile.getParse();
+
+        for (Syntax.Statement statement : currentParseResult.statements()) {
+            collect(statement);
+        }
+
+        addPendingReferences();
+    }
+
+    private void collect(Syntax.Statement statement) {
+        switch (statement) {
+            case Syntax.Statement.Use use -> {
+                if (use.use().stringValue().equals(shape.getId().toString())) {
+                    pendingUseRefs.add(use);
+                }
+            }
+
+            case Syntax.Statement.Mixins mixins -> {
+                for (var mixin : mixins.mixins()) {
+                    addShapeReference(mixin);
+                }
+            }
+
+            case Syntax.Statement.ForResource forResource -> addShapeReference(forResource.resource());
+
+            case Syntax.Statement.MemberDef memberDef -> {
+                if (memberDef.target() != null) {
+                    addShapeReference(memberDef.target());
+                }
+            }
+
+            case Syntax.Statement.TraitApplication traitApplication -> collectTrait(traitApplication);
+
+            case Syntax.Statement.NodeMemberDef nodeMemberDef -> collectNodeMember(nodeMemberDef);
+
+            default -> {
+            }
+        }
+    }
+
+    private void collectTrait(Syntax.Statement.TraitApplication traitApplication) {
+        findShape(traitApplication.id().stringValue()).ifPresent(traitShape -> {
+            if (traitShape.getId().equals(shape.getId())) {
+                pendingRefs.add(traitApplication.id());
+            }
+            traitValueWalker.walk(traitApplication.value(), traitShape);
+        });
+    }
+
+    private void collectNodeMember(Syntax.Statement.NodeMemberDef nodeMemberDef) {
+        createView(nodeMemberDef)
+                .map(StatementView::nearestShapeDefBefore)
+                .map(shapeDef -> Builtins.getMemberTargetForShapeType(
+                        shapeDef.shapeType().stringValue(),
+                        nodeMemberDef.name().stringValue()))
+                .ifPresent(memberTarget -> nodeMemberWalker.walk(nodeMemberDef.value(), memberTarget));
+    }
+
+    private boolean startsWithId(Shape s) {
+        return s.getId().getNamespace().equals(shape.getId().getNamespace())
+               && s.getId().getName().equals(shape.getId().getName());
+    }
+
+    private void addShapeReference(Syntax.Node.Str token) {
+        if (findShape(token.stringValue())
+                .filter(s -> s.getId().equals(shape.getId()))
+                .isPresent()) {
+            pendingRefs.add(token);
+        }
+    }
+
+    private Optional<Shape> findShape(String nameOrId) {
+        return ShapeSearch.findShape(currentParseResult, nameOrId, model);
+    }
+
+    private Optional<StatementView> createView(Syntax.Statement statement) {
+        return StatementView.createAt(currentParseResult, statement);
+    }
+
+    private void addDefinitionReference(Project project) {
+        var sourceLocation = shape.getSourceLocation();
+        var projectFile = project.getProjectFile(LspAdapter.toUri(sourceLocation.getFilename()));
+        if (!(projectFile instanceof IdlFile idl)) {
+            return;
+        }
+
+        var parseResult = idl.getParse();
+        int documentIndex = idl.document().indexOfPosition(LspAdapter.toPosition(sourceLocation));
+        var statement = StatementView.createAt(parseResult, documentIndex)
+                .map(StatementView::getStatement)
+                .orElse(null);
+        if (statement instanceof Syntax.Statement.ShapeDef shapeDef) {
+            definitionReferences.add(new DefinitionReference(idl, shapeDef.shapeName()));
+        }
+    }
+
+    private void addIdRef(Syntax.Node.Str id) {
+        if (findShape(id.stringValue())
+                .filter(this::startsWithId)
+                .isPresent()) {
+            pendingRefs.add(id);
+        }
+    }
+
+    /**
+     * Walks a {@link Syntax.Node}, whose structure is defined by a {@link Shape},
+     * to find all references to shapes in that node.
+     *
+     * @param model The model with the shape defining the node's structure
+     * @param references The references to consume found shape references
+     *
+     * @implNote This is very similar to {@link NodeSearch}, but walks all children
+     *  instead of along a specific path, and only looks for shapes with {@code idRef}.
+     *  It also doesn't use {@link DynamicMemberTarget}s, as right now there aren't
+     *  any cases where a dynamic member target could provide shape references.
+     */
+    private record ShapeReferencesNodeWalker(Model model, References references) {
+        private void walk(Syntax.Node node, Shape nodeShape) {
+            if (nodeShape == null) {
+                return;
+            }
+
+            switch (node) {
+                case Syntax.Node.Obj obj -> walk(obj.kvps(), nodeShape);
+
+                case Syntax.Node.Kvps kvps -> walkKvps(kvps, nodeShape);
+
+                case Syntax.Node.Arr arr -> walkArr(arr, nodeShape);
+
+                case Syntax.Node.Str str -> {
+                    if (nodeShape.hasTrait(IdRefTrait.class)) {
+                        references.addIdRef(str);
+                    }
+                }
+
+                case null, default -> {
+                }
+            }
+        }
+
+        private void walkArr(Syntax.Node.Arr arr, Shape nodeShape) {
+            if (!(nodeShape instanceof ListShape listShape)) {
+                return;
+            }
+
+            if (listShape.getMember().hasTrait(IdRefTrait.ID)) {
+                for (var elem : arr.elements()) {
+                    walkIdRef(elem);
+                }
+            } else {
+                var target = getTarget(listShape.getMember());
+                if (target == null) {
+                    return;
+                }
+                for (var elem : arr.elements()) {
+                    walk(elem, target);
+                }
+            }
+        }
+
+        private void walkKvps(Syntax.Node.Kvps kvps, Shape nodeShape) {
+            if (!ShapeSearch.isObjectShape(nodeShape)) {
+                return;
+            }
+
+            if (nodeShape instanceof MapShape mapShape) {
+                walkMap(kvps, mapShape);
+            } else {
+                walkAggregate(kvps, nodeShape);
+            }
+        }
+
+        private void walkMap(Syntax.Node.Kvps kvps, MapShape mapShape) {
+            var keyMember = mapShape.getKey();
+            var valueMember = mapShape.getValue();
+
+            boolean keyHasIdRef = keyMember.hasTrait(IdRefTrait.ID);
+            boolean valueHasIdRef = valueMember.hasTrait(IdRefTrait.ID);
+
+            if (keyHasIdRef && valueHasIdRef) {
+                for (var kvp : kvps.kvps()) {
+                    walkIdRef(kvp.key());
+                    walkIdRef(kvp.value());
+                }
+            } else if (keyHasIdRef) {
+                var valueTarget = model.getShape(mapShape.getValue().getTarget()).orElse(null);
+                for (var kvp : kvps.kvps()) {
+                    walkIdRef(kvp.key());
+                    walk(kvp.value(), valueTarget);
+                }
+            } else if (valueHasIdRef) {
+                var keyTarget = model.getShape(mapShape.getKey().getTarget()).orElse(null);
+                for (var kvp : kvps.kvps()) {
+                    walk(kvp.key(), keyTarget);
+                    walkIdRef(kvp.value());
+                }
+            } else {
+                var keyTarget = getTarget(keyMember);
+                var valueTarget = getTarget(valueMember);
+                for (var kvp : kvps.kvps()) {
+                    walk(kvp.key(), keyTarget);
+                    walk(kvp.value(), valueTarget);
+                }
+            }
+        }
+
+        private void walkAggregate(Syntax.Node.Kvps kvps, Shape nodeShape) {
+            for (var kvp : kvps.kvps()) {
+                var member = nodeShape.getMember(kvp.key().stringValue()).orElse(null);
+                if (member == null) {
+                    continue;
+                }
+
+                if (member.hasTrait(IdRefTrait.ID)) {
+                    walkIdRef(kvp.value());
+                } else {
+                    var target = getTarget(member);
+                    walk(kvp.value(), target);
+                }
+            }
+        }
+
+        private void walkIdRef(Syntax.Node node) {
+            if (node instanceof Syntax.Node.Str str) {
+                references.addIdRef(str);
+            }
+        }
+
+        private Shape getTarget(MemberShape member) {
+            return model.getShape(member.getTarget()).orElse(null);
+        }
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/language/ReferencesHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/ReferencesHandler.java
@@ -73,14 +73,14 @@ public record ReferencesHandler(Project project, IdlFile idlFile) {
         private static ResponseErrorException notSupported() {
             var error = new ResponseError();
             error.setCode(ResponseErrorCode.RequestFailed);
-            error.setMessage("Not supported here.");
+            error.setMessage("Finding references not supported here.");
             return new ResponseErrorException(error);
         }
 
         private static ResponseErrorException noModel() {
             var error = new ResponseError();
             error.setCode(ResponseErrorCode.RequestFailed);
-            error.setMessage("Model is too broken.");
+            error.setMessage("Model is too broken to find references.");
             return new ResponseErrorException(error);
         }
     }

--- a/src/main/java/software/amazon/smithy/lsp/language/ReferencesHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/ReferencesHandler.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import software.amazon.smithy.lsp.document.DocumentId;
+import software.amazon.smithy.lsp.project.IdlFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.protocol.LspAdapter;
+import software.amazon.smithy.lsp.syntax.StatementView;
+import software.amazon.smithy.model.Model;
+import software.amazon.smithy.model.shapes.Shape;
+
+public record ReferencesHandler(Project project, IdlFile idlFile) {
+    /**
+     * @param params The request params
+     * @return A list of locations of the found refs
+     */
+    public List<? extends Location> handle(ReferenceParams params) {
+        var config = Config.create(project, idlFile, params.getPosition());
+        var references = References.findReferences(config.model(), config.shape(), project);
+        return toLocations(references);
+    }
+
+    record Config(DocumentId id, Shape shape, Model model, IdlFile definitionFile) {
+        static Config create(Project project, IdlFile idlFile, Position position) {
+            DocumentId id = idlFile.document().copyDocumentId(position);
+            if (id == null || id.idSlice().isEmpty()) {
+                throw notSupported();
+            }
+
+            var parseResult = idlFile.getParse();
+            int documentIndex = idlFile.document().indexOfPosition(position);
+            var idlPosition = StatementView.createAt(parseResult, documentIndex)
+                    .map(IdlPosition::of)
+                    .orElse(null);
+            if (idlPosition == null) {
+                throw notSupported();
+            }
+
+            var model = project.modelResult().getResult().orElse(null);
+            if (model == null) {
+                throw noModel();
+            }
+
+            var shapeReference = ShapeSearch.getShapeReference(idlPosition, id, model);
+            if (shapeReference.isEmpty()) {
+                throw notSupported();
+            }
+
+            var shape = shapeReference.get();
+            var definitionFile = project.getDefinitionFile(shape);
+
+            IdlFile idlDefinitionFile = null;
+            if (definitionFile instanceof IdlFile idl) {
+                idlDefinitionFile = idl;
+            }
+
+            return new Config(id, shape, model, idlDefinitionFile);
+        }
+
+        private static ResponseErrorException notSupported() {
+            var error = new ResponseError();
+            error.setCode(ResponseErrorCode.RequestFailed);
+            error.setMessage("Not supported here.");
+            return new ResponseErrorException(error);
+        }
+
+        private static ResponseErrorException noModel() {
+            var error = new ResponseError();
+            error.setCode(ResponseErrorCode.RequestFailed);
+            error.setMessage("Model is too broken.");
+            return new ResponseErrorException(error);
+        }
+    }
+
+    private List<Location> toLocations(References references) {
+        List<Location> locations = new ArrayList<>();
+        for (var fileReferences : references.fileReferences()) {
+            String uri = LspAdapter.toUri(fileReferences.idlFile().path());
+
+            for (var ref : fileReferences.refs()) {
+                addLocation(locations, uri, fileReferences.idlFile().document().rangeOfValue(ref));
+            }
+
+            for (var use : fileReferences.useRefs()) {
+                addLocation(locations, uri, fileReferences.idlFile().document().rangeOfValue(use.use()));
+            }
+        }
+
+        for (var definitionRef : references.definitionReferences()) {
+            String uri = LspAdapter.toUri(definitionRef.idlFile().path());
+            addLocation(locations, uri, definitionRef.idlFile().document().rangeOfValue(definitionRef.ref()));
+        }
+
+        return locations;
+    }
+
+    private void addLocation(List<Location> locations, String uri, Range range) {
+        if (range != null) {
+            locations.add(new Location(uri, range));
+        }
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/language/RenameHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/RenameHandler.java
@@ -106,13 +106,12 @@ public record RenameHandler(Project project, IdlFile idlFile) {
                 return;
             }
 
-            var conflictingShape = ShapeSearch.findShape(sourceFile.getParse(), conflictingId, config.model())
-                    .orElse(null);
-            if (conflictingShape == null) {
+            var conflictingShape = ShapeSearch.findShape(sourceFile.getParse(), conflictingId, config.model());
+            if (conflictingShape.isEmpty()) {
                 return;
             }
 
-            var references = References.findReferences(config.model(), conflictingShape, sourceFile);
+            var references = References.findReferences(config.model(), conflictingShape.get(), sourceFile);
             for (var fileReferences : references.fileReferences()) {
                 addConflictRenames(fileReferences, conflictingId);
             }

--- a/src/main/java/software/amazon/smithy/lsp/language/RenameHandler.java
+++ b/src/main/java/software/amazon/smithy/lsp/language/RenameHandler.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.lsp4j.PrepareRenameParams;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
+import software.amazon.smithy.lsp.project.IdlFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.protocol.LspAdapter;
+import software.amazon.smithy.lsp.syntax.Syntax;
+import software.amazon.smithy.model.shapes.ShapeId;
+import software.amazon.smithy.model.shapes.ShapeIdSyntaxException;
+
+public record RenameHandler(Project project, IdlFile idlFile) {
+    /**
+     * @param params The request params
+     * @return The range of the identifier to rename
+     */
+    public Range prepare(PrepareRenameParams params) {
+        var config = ReferencesHandler.Config.create(project, idlFile, params.getPosition());
+        return getRenameRange(config.id().range(), config.id().copyIdValue());
+    }
+
+    /**
+     * @param params The request params
+     * @return A workspace edit that applies the rename
+     */
+    public WorkspaceEdit handle(RenameParams params) {
+        var config = ReferencesHandler.Config.create(project, idlFile, params.getPosition());
+        var edits = getEdits(config, params.getNewName());
+        return new WorkspaceEdit(edits);
+    }
+
+    private Map<String, List<TextEdit>> getEdits(ReferencesHandler.Config config, String newName) {
+        String namespace = config.shape().getId().getNamespace();
+
+        ShapeId renamedId;
+        try {
+            renamedId = ShapeId.fromRelative(namespace, newName);
+        } catch (ShapeIdSyntaxException e) {
+            throw invalidShapeId(e);
+        }
+
+        var projectEdits = new ProjectEdits(config, newName, renamedId, new HashMap<>());
+        projectEdits.collect(project);
+
+        return projectEdits.edits;
+    }
+
+    private record ProjectEdits(
+            ReferencesHandler.Config config,
+            String newName,
+            ShapeId renamedShapeId,
+            Map<String, List<TextEdit>> edits
+    ) {
+        private enum FileEditType {
+            CONFLICT,
+            SIMPLE
+        }
+
+        private void collect(Project project) {
+            var references = References.findReferences(config.model(), config.shape(), project);
+
+            addEdits(references);
+            deconflictDefinition();
+        }
+
+        private void addEdits(References allReferences) {
+            for (var fileReferences : allReferences.fileReferences()) {
+                FileEditType fileEditType = getEditType(fileReferences.idlFile());
+                if (fileEditType == FileEditType.CONFLICT) {
+                    addConflictRenames(fileReferences, renamedShapeId.toString());
+                } else {
+                    addSimpleRenames(fileReferences);
+                }
+            }
+
+            for (var definitionReference : allReferences.definitionReferences()) {
+                var uri = checkIfJar(definitionReference.idlFile());
+
+                addSimpleRename(uri, definitionReference.idlFile(), definitionReference.ref());
+            }
+        }
+
+        private void deconflictDefinition() {
+            var sourceFile = config.definitionFile();
+            if (sourceFile == null) {
+                return;
+            }
+
+            String conflictingId = getConflictingImport(sourceFile, newName);
+            if (conflictingId == null) {
+                return;
+            }
+
+            var conflictingShape = ShapeSearch.findShape(sourceFile.getParse(), conflictingId, config.model())
+                    .orElse(null);
+            if (conflictingShape == null) {
+                return;
+            }
+
+            var references = References.findReferences(config.model(), conflictingShape, sourceFile);
+            for (var fileReferences : references.fileReferences()) {
+                addConflictRenames(fileReferences, conflictingId);
+            }
+            // Note: No deconflict needed for the definition (plus it won't be picked up by allReferences)
+        }
+
+        private void addConflictRenames(References.FileReferences fileReferences, String conflictingId) {
+            var uri = checkIfJar(fileReferences.idlFile());
+
+            for (var ref : fileReferences.refs()) {
+                var range = fileReferences.idlFile().document().rangeOfValue(ref);
+                if (range == null) {
+                    continue;
+                }
+
+                var referenceId = ref.stringValue();
+                var renamedId = conflictingId;
+                if (referenceId.contains("$")) {
+                    renamedId = conflictingId + "$" + referenceId.split("\\$")[1];
+                }
+
+                add(uri, range, renamedId);
+            }
+
+            for (var use : fileReferences.useRefs()) {
+                var range = fileReferences.idlFile().document().rangeOf(use);
+                if (range == null) {
+                    continue;
+                }
+
+                add(uri, range, "");
+            }
+        }
+
+        private void addSimpleRenames(References.FileReferences fileReferences) {
+            var uri = checkIfJar(fileReferences.idlFile());
+
+            for (var ref : fileReferences.refs()) {
+                addSimpleRename(uri, fileReferences.idlFile(), ref);
+            }
+
+            for (var use : fileReferences.useRefs()) {
+                var range = fileReferences.idlFile().document().rangeOfValue(use.use());
+                if (range == null) {
+                    continue;
+                }
+
+                var referenceId = use.use().stringValue();
+                var renameRange = getRenameRange(range, referenceId);
+                add(uri, renameRange, newName);
+            }
+        }
+
+        private void addSimpleRename(String uri, IdlFile idlFile, Syntax.Node.Str ref) {
+            var range = idlFile.document().rangeOfValue(ref);
+            if (range == null) {
+                return;
+            }
+
+            var referenceId = ref.stringValue();
+            var renameRange = getRenameRange(range, referenceId);
+            add(uri, renameRange, newName);
+        }
+
+        private String checkIfJar(IdlFile idlFile) {
+            String uri = LspAdapter.toUri(idlFile.path());
+            if (!LspAdapter.isJarFile(uri) && !LspAdapter.isSmithyJarFile(uri)) {
+                return uri;
+            }
+
+            throw referencedInJar(uri);
+        }
+
+        private FileEditType getEditType(IdlFile idlFile) {
+            if (isDefinitionFile(idlFile) || !conflicts(idlFile)) {
+                return FileEditType.SIMPLE;
+            } else {
+                return FileEditType.CONFLICT;
+            }
+        }
+
+        private boolean isDefinitionFile(IdlFile idlFile) {
+            return config.definitionFile() != null && config.definitionFile().path().equals(idlFile.path());
+        }
+
+        private boolean conflicts(IdlFile idlFile) {
+            if (renamedShapeId == null) {
+                return false;
+            }
+
+            String fileNamespace = idlFile.getParse().namespace().namespace();
+            if (!renamedShapeId.getNamespace().equals(fileNamespace)) {
+                ShapeId renamedCurrentScope = ShapeId.fromRelative(fileNamespace, newName);
+                if (config.model().getShape(renamedCurrentScope).isPresent()) {
+                    return true;
+                }
+            }
+
+            return getConflictingImport(idlFile, newName) != null;
+        }
+
+        private void add(String uri, Range renamedRange, String renamed) {
+            var edit = new TextEdit(renamedRange, renamed);
+            edits.computeIfAbsent(uri, k -> new ArrayList<>()).add(edit);
+        }
+    }
+
+    private static ResponseErrorException invalidShapeId(ShapeIdSyntaxException e) {
+        var responseError = new ResponseError();
+        responseError.setCode(ResponseErrorCode.RequestFailed);
+        responseError.setMessage("Renamed shape id would be invalid: " + e.getMessage());
+        return new ResponseErrorException(responseError);
+    }
+
+    private static ResponseErrorException referencedInJar(String uri) {
+        var error = new ResponseError();
+        error.setCode(ResponseErrorCode.RequestFailed);
+        error.setMessage("Can't rename shape referenced in jar: " + uri);
+        return new ResponseErrorException(error);
+    }
+
+    private static Range getRenameRange(Range range, String idString) {
+        int originalStartCharacter = range.getStart().getCharacter();
+        int hashIdx = idString.indexOf('#');
+        if (hashIdx >= 0) {
+            int currentCharacter = range.getStart().getCharacter();
+            range.getStart().setCharacter(currentCharacter + hashIdx + 1);
+        }
+        int dollarIdx = idString.indexOf('$');
+        if (dollarIdx >= 0) {
+            range.getEnd().setCharacter(originalStartCharacter + dollarIdx);
+        }
+        return range;
+    }
+
+    private static String getConflictingImport(IdlFile idlFile, String newName) {
+        String matcher = "#" + newName;
+        for (String imported : idlFile.getParse().imports().imports()) {
+            if (imported.endsWith(matcher)) {
+                return imported;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/software/amazon/smithy/lsp/project/Project.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/Project.java
@@ -203,6 +203,15 @@ public final class Project {
         return buildFiles.getByPath(path);
     }
 
+    /**
+     * @param shape The shape to get the definition file of
+     * @return The file the shape is defined in, or {@code null} if the file
+     *  isn't in this project
+     */
+    public SmithyFile getDefinitionFile(Shape shape) {
+        return smithyFiles.get(shape.getSourceLocation().getFilename());
+    }
+
     public synchronized void validateConfig() {
         this.configEvents = ProjectConfigLoader.validateBuildFiles(buildFiles);
     }

--- a/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
@@ -132,6 +132,10 @@ final class Parser extends SimpleParser {
         this.rewind(pos, line + 1, pos - lineIndex + 1);
     }
 
+    private int currentLine() {
+        return line() - 1;
+    }
+
     private Syntax.Node traitNode() {
         skip(); // '('
         ws();
@@ -214,7 +218,7 @@ final class Parser extends SimpleParser {
             skip();
         } while (!isWs() && !isStructuralBreakpoint() && !eof());
         int end = position();
-        return new Syntax.Ident(start, end, document.copySpan(start, end));
+        return new Syntax.Ident(currentLine(), start, end, document.copySpan(start, end));
     }
 
     private Syntax.Node.Obj obj() {
@@ -393,12 +397,12 @@ final class Parser extends SimpleParser {
 
                 rewindTo(end + 3);
                 int strEnd = position();
-                return new Syntax.Node.Str(start, strEnd, document.copySpan(start + 3, strEnd - 3));
+                return new Syntax.Node.Str(currentLine(), start, strEnd, document.copySpan(start + 3, strEnd - 3));
             }
 
             // Empty string
             int strEnd = position();
-            return new Syntax.Node.Str(start, strEnd, "");
+            return new Syntax.Node.Str(currentLine(), start, strEnd, "");
         }
 
         int last = '"';
@@ -408,7 +412,7 @@ final class Parser extends SimpleParser {
             if (is('"') && last != '\\') {
                 skip(); // '"'
                 int strEnd = position();
-                return new Syntax.Node.Str(start, strEnd, document.copySpan(start + 1, strEnd - 1));
+                return new Syntax.Node.Str(currentLine(), start, strEnd, document.copySpan(start + 1, strEnd - 1));
             }
             last = peek();
             skip();
@@ -972,7 +976,7 @@ final class Parser extends SimpleParser {
             addErr(start, end, "expected identifier");
             return Syntax.Ident.EMPTY;
         }
-        return new Syntax.Ident(start, end, document.copySpan(start, end));
+        return new Syntax.Ident(currentLine(), start, end, document.copySpan(start, end));
     }
 
     private void addErr(int start, int end, String message) {

--- a/src/main/java/software/amazon/smithy/lsp/syntax/StatementView.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/StatementView.java
@@ -34,6 +34,15 @@ public record StatementView(Syntax.IdlParseResult parseResult, int statementInde
 
     /**
      * @param parseResult The parse result to create a view of
+     * @param statement The statement to create the view at
+     * @return An optional view of the given statement
+     */
+    public static Optional<StatementView> createAt(Syntax.IdlParseResult parseResult, Syntax.Statement statement) {
+        return createAt(parseResult, statement.start());
+    }
+
+    /**
+     * @param parseResult The parse result to create a view of
      * @param documentIndex The index within the underlying document
      * @return An optional view of the statement the given documentIndex is within
      *  in the given parse result, or empty if the index is not within a statement

--- a/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
@@ -293,12 +293,18 @@ public final class Syntax {
          * identifiers, so this class a single subclass {@link Ident}.
          */
         public static sealed class Str extends Node {
+            final int line;
             final String value;
 
-            Str(int start, int end, String value) {
+            Str(int line, int start, int end, String value) {
+                this.line = line;
                 this.start = start;
                 this.end = end;
                 this.value = value;
+            }
+
+            public int line() {
+                return line;
             }
 
             public String stringValue() {
@@ -798,10 +804,10 @@ public final class Syntax {
      * (i.e. `.`, `#`, `$`, `_` digits, alphas).
      */
     public static final class Ident extends Node.Str {
-        static final Ident EMPTY = new Ident(-1, -1, "");
+        static final Ident EMPTY = new Ident(-1, -1, -1, "");
 
-        Ident(int start, int end, String value) {
-            super(start, end, value);
+        Ident(int line, int start, int end, String value) {
+            super(line, start, end, value);
         }
 
         public boolean isEmpty() {

--- a/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Syntax.java
@@ -293,18 +293,18 @@ public final class Syntax {
          * identifiers, so this class a single subclass {@link Ident}.
          */
         public static sealed class Str extends Node {
-            final int line;
+            final int lineNumber;
             final String value;
 
-            Str(int line, int start, int end, String value) {
-                this.line = line;
+            Str(int lineNumber, int start, int end, String value) {
+                this.lineNumber = lineNumber;
                 this.start = start;
                 this.end = end;
                 this.value = value;
             }
 
-            public int line() {
-                return line;
+            public int lineNumber() {
+                return lineNumber;
             }
 
             public String stringValue() {
@@ -806,8 +806,8 @@ public final class Syntax {
     public static final class Ident extends Node.Str {
         static final Ident EMPTY = new Ident(-1, -1, -1, "");
 
-        Ident(int line, int start, int end, String value) {
-            super(line, start, end, value);
+        Ident(int lineNumber, int start, int end, String value) {
+            super(lineNumber, start, end, value);
         }
 
         public boolean isEmpty() {

--- a/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/LspMatchers.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.InlayHint;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
@@ -154,6 +155,35 @@ public final class LspMatchers {
                             + "," + item.getPosition().getCharacter()+ "'");
                 }
 
+            }
+        };
+    }
+
+    public static Matcher<Location> isLocationIncluding(String uri, Position position) {
+        return new CustomTypeSafeMatcher<>("a location in " + uri + " on the same line of, and including " + position) {
+            @Override
+            protected boolean matchesSafely(Location item) {
+                return rangeMatches(item.getRange()) && item.getUri().equals(uri);
+            }
+
+            private boolean rangeMatches(Range range) {
+                var start = range.getStart();
+                var end = range.getEnd();
+                return start.getLine() == position.getLine()
+                       && end.getLine() == position.getLine()
+                       && start.getCharacter() <= position.getCharacter()
+                       && end.getCharacter() > position.getCharacter();
+            }
+
+            @Override
+            protected void describeMismatchSafely(Location item, Description mismatchDescription) {
+                if (!item.getUri().equals(uri)) {
+                    mismatchDescription.appendText("uri was " + item.getUri());
+                }
+
+                if (!rangeMatches(item.getRange())) {
+                    mismatchDescription.appendText("range was " + item.getRange());
+                }
             }
         };
     }

--- a/src/test/java/software/amazon/smithy/lsp/RequestBuilders.java
+++ b/src/test/java/software/amazon/smithy/lsp/RequestBuilders.java
@@ -26,7 +26,11 @@ import org.eclipse.lsp4j.FileEvent;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.PrepareRenameParams;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.ReferenceContext;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
@@ -241,6 +245,29 @@ public final class RequestBuilders {
                     new TextDocumentIdentifier(uri),
                     new Position(line, character),
                     new CompletionContext(CompletionTriggerKind.Invoked));
+        }
+
+        public ReferenceParams buildReference() {
+            return new ReferenceParams(
+                    new TextDocumentIdentifier(uri),
+                    new Position(line, character),
+                    new ReferenceContext(true)
+            );
+        }
+
+        public RenameParams buildRename(String newName) {
+            return new RenameParams(
+                    new TextDocumentIdentifier(uri),
+                    new Position(line, character),
+                    newName
+            );
+        }
+
+        public PrepareRenameParams buildPrepareRename() {
+            return new PrepareRenameParams(
+                    new TextDocumentIdentifier(uri),
+                    new Position(line, character)
+            );
         }
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/TextWithPositions.java
+++ b/src/test/java/software/amazon/smithy/lsp/TextWithPositions.java
@@ -39,7 +39,8 @@ public record TextWithPositions(String text, Position... positions) {
         Document document = Document.of(safeString(raw));
         List<Position> positions = new ArrayList<>();
 
-        Position lastPosition = null;
+        int lastLine = -1;
+        int lineMarkerCount = 0;
         int i = 0;
         while (true) {
             int next = document.nextIndexOf(POSITION_MARKER, i);
@@ -47,12 +48,16 @@ public record TextWithPositions(String text, Position... positions) {
                 break;
             }
             Position position = document.positionAtIndex(next);
-            if (lastPosition != null && position.getLine() == lastPosition.getLine()) {
-                // If there's two or more markers on the same line, any markers after the
-                // first will be off by one when we do the replacement.
-                position.setCharacter(position.getCharacter() - 1);
+
+            // If there's two or more markers on the same line, any markers after the
+            // first will be off by one when we do the replacement.
+            if (position.getLine() != lastLine) {
+                lastLine = position.getLine();
+                lineMarkerCount = 1;
+            } else {
+                position.setCharacter(position.getCharacter() - lineMarkerCount);
+                lineMarkerCount++;
             }
-            lastPosition = position;
             positions.add(position);
             i = next + 1;
         }

--- a/src/test/java/software/amazon/smithy/lsp/UtilMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/UtilMatchers.java
@@ -67,4 +67,32 @@ public final class UtilMatchers {
             }
         };
     }
+
+    public static Matcher<String> stringEquals(String expected) {
+        return new CustomTypeSafeMatcher<>(expected) {
+            @Override
+            protected boolean matchesSafely(String item) {
+                return expected.equals(item);
+            }
+
+            @Override
+            protected void describeMismatchSafely(String item, Description mismatchDescription) {
+                mismatchDescription.appendText("was: " + item);
+            }
+        };
+    }
+
+    public static Matcher<Runnable> throwsWithMessage(Matcher<String> message) {
+        return new CustomTypeSafeMatcher<>("Throws " + message) {
+            @Override
+            protected boolean matchesSafely(Runnable item) {
+                try {
+                    item.run();
+                    return false;
+                } catch (Exception e) {
+                    return message.matches(e.getMessage());
+                }
+            }
+        };
+    }
 }

--- a/src/test/java/software/amazon/smithy/lsp/UtilMatchers.java
+++ b/src/test/java/software/amazon/smithy/lsp/UtilMatchers.java
@@ -5,6 +5,8 @@
 
 package software.amazon.smithy.lsp;
 
+import static software.amazon.smithy.lsp.document.DocumentTest.safeString;
+
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.util.Optional;
@@ -72,7 +74,7 @@ public final class UtilMatchers {
         return new CustomTypeSafeMatcher<>(expected) {
             @Override
             protected boolean matchesSafely(String item) {
-                return expected.equals(item);
+                return safeString(expected).equals(item);
             }
 
             @Override

--- a/src/test/java/software/amazon/smithy/lsp/language/ReferencesHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/ReferencesHandlerTest.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package software.amazon.smithy.lsp.language;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.everyItem;
+import static software.amazon.smithy.lsp.LspMatchers.isLocationIncluding;
+import static software.amazon.smithy.lsp.UtilMatchers.throwsWithMessage;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.hamcrest.Matcher;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.lsp.RequestBuilders;
+import software.amazon.smithy.lsp.TestWorkspace;
+import software.amazon.smithy.lsp.TextWithPositions;
+import software.amazon.smithy.lsp.project.IdlFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.project.ProjectTest;
+
+public class ReferencesHandlerTest {
+    @Test
+    public void shapeDef() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                string %Foo
+                
+                structure Bar {
+                    foo: %Foo
+                }
+                
+                resource Baz {
+                    identifiers: {
+                        foo: %Foo
+                    }
+                    properties: {
+                        foo: %Foo
+                    }
+                    put: %Foo
+                }
+                
+                service Bux {
+                    operations: [%Foo]
+                    rename: {
+                        "%com.foo#Foo": "Renamed"
+                    }
+                }
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void traitId() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure %myTrait {
+                    ref: ShapeId
+                }
+                
+                @idRef
+                string ShapeId
+                
+                @%myTrait
+                string Foo
+                
+                @%myTrait(ref: %myTrait)
+                string Bar
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void idRef() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    ref: %ShapeId
+                }
+                
+                @idRef
+                string %ShapeId
+                
+                @myTrait(ref: %ShapeId)
+                string Foo
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void stringIdRef() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: "%com.foo#Foo")
+                string %Foo
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void mapIdRef() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                map myTrait {
+                    @idRef
+                    key: String
+                
+                    @idRef
+                    value: String
+                }
+                
+                @myTrait(
+                    "%com.foo#Foo": %Foo
+                    "%com.foo#Foo$foo": %Foo$foo
+                )
+                structure %Foo {
+                    foo: %Foo
+                }
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void rootShapeReferencesIncludeIdsWithMembers() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: %Foo$foo)
+                structure %Foo {
+                    foo: String
+                }
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void inlineIoReferences() {
+        // No refs on the actual inline shape def. It isn't named in the text, so
+        // don't consider it a ref.
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: %OpInput)
+                operation Op {
+                    input := {}
+                }
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void serviceRenameReferences() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                service Foo {
+                    version: "1"
+                    rename: {
+                        "%com.foo#Bar": "Baz"
+                    }
+                }
+                
+                @myTrait(ref: %Bar)
+                structure %Bar {}
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void referencesInNodeMembers() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: %Bar
+                }
+                
+                resource Foo {
+                    identifiers: {
+                        id: %Bar
+                    }
+                }
+                
+                @myTrait(ref: %Bar)
+                string %Bar
+                """);
+        var result = getLocations(twp);
+
+        assertHasAllLocations(result, twp.positions());
+    }
+
+    @Test
+    public void unsupportedReferences() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @mixin
+                @myTrait(ref: Foo$%foo)
+                structure Foo {
+                    %foo: String
+                }
+                
+                operation Op {
+                    %input := {
+                        %foo: String
+                    }
+                    %output: OpOutput
+                    %errors: []
+                }
+                
+                structure OpOutput with [Foo] {
+                    %$foo
+                }
+                """);
+        var workspace = TestWorkspace.singleModel(twp.text());
+        var project = ProjectTest.load(workspace.getRoot());
+        var uri = workspace.getUri("main.smithy");
+        IdlFile idlFile = (IdlFile) project.getProjectFile(uri);
+
+        for (var position : twp.positions()) {
+            assertThat(() -> ReferencesHandler.Config.create(project, idlFile, position),
+                    throwsWithMessage(containsString("Not supported")));
+        }
+    }
+
+    private static void assertHasAllLocations(GetLocationsResult result, Position... positions) {
+        String uri = result.workspace.getUri("main.smithy");
+        List<Matcher<? super Location>> matchers = new ArrayList<>();
+        for (Position position : positions) {
+            matchers.add(isLocationIncluding(uri, position));
+        }
+        assertThat(result.locations, everyItem(containsInAnyOrder(matchers)));
+    }
+
+    private record GetLocationsResult(TestWorkspace workspace, List<List<Location>> locations) {}
+
+    private static GetLocationsResult getLocations(TextWithPositions twp) {
+        TestWorkspace workspace = TestWorkspace.singleModel(twp.text());
+        Project project = ProjectTest.load(workspace.getRoot());
+        String uri = workspace.getUri("main.smithy");
+        IdlFile idlFile = (IdlFile) project.getProjectFile(uri);
+
+        List<List<Location>> locations = new ArrayList<>();
+        ReferencesHandler handler = new ReferencesHandler(project, idlFile);
+        for (Position position : twp.positions()) {
+            ReferenceParams params = RequestBuilders.positionRequest()
+                    .uri(uri)
+                    .position(position)
+                    .buildReference();
+            var result = handler.handle(params);
+            locations.add(new ArrayList<>(result));
+        }
+
+        return new GetLocationsResult(workspace, locations);
+    }
+}

--- a/src/test/java/software/amazon/smithy/lsp/language/ReferencesHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/ReferencesHandlerTest.java
@@ -292,7 +292,7 @@ public class ReferencesHandlerTest {
 
         for (var position : twp.positions()) {
             assertThat(() -> ReferencesHandler.Config.create(project, idlFile, position),
-                    throwsWithMessage(containsString("Not supported")));
+                    throwsWithMessage(containsString("not supported")));
         }
     }
 

--- a/src/test/java/software/amazon/smithy/lsp/language/RenameHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/RenameHandlerTest.java
@@ -1,0 +1,1016 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.lsp.language;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static software.amazon.smithy.lsp.UtilMatchers.stringEquals;
+import static software.amazon.smithy.lsp.UtilMatchers.throwsWithMessage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.junit.jupiter.api.Test;
+import software.amazon.smithy.lsp.RequestBuilders;
+import software.amazon.smithy.lsp.TestWorkspace;
+import software.amazon.smithy.lsp.TextWithPositions;
+import software.amazon.smithy.lsp.document.Document;
+import software.amazon.smithy.lsp.project.IdlFile;
+import software.amazon.smithy.lsp.project.Project;
+import software.amazon.smithy.lsp.project.ProjectTest;
+
+public class RenameHandlerTest {
+    @Test
+    public void renamesRootShapesInTheSameFile() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                string %Foo
+                
+                @myTrait(ref: %Foo)
+                structure Bar {
+                    foo: %Foo
+                }
+                """);
+        var result = getEdits("Baz", twp);
+
+        assertHasEditsForAllPositions(result, twp);
+
+        assertAllEditsMake(result, """
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                string Baz
+                
+                @myTrait(ref: Baz)
+                structure Bar {
+                    foo: Baz
+                }
+                """);
+    }
+
+    @Test
+    public void renamesAbsoluteIds() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                string %Foo
+                
+                @myTrait(ref: com.foo#%Foo)
+                structure Bar {
+                    foo: com.foo#%Foo
+                }
+                """);
+        var result = getEdits("Baz", twp);
+
+        assertHasEditsForAllPositions(result, twp);
+
+        assertAllEditsMake(result, """
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                string Baz
+                
+                @myTrait(ref: com.foo#Baz)
+                structure Bar {
+                    foo: com.foo#Baz
+                }
+                """);
+    }
+
+    @Test
+    public void renamesRootShapeAbsoluteIdsWithMember() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: %com.foo#Foo$foo)
+                structure %Foo {
+                    foo: String
+                }
+                """);
+        var result = getEdits("Bar", twp);
+
+        assertHasEditsForAllPositions(result, twp);
+
+        assertAllEditsMake(result, """
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: com.foo#Bar$foo)
+                structure Bar {
+                    foo: String
+                }
+                """);
+    }
+
+    @Test
+    public void multiFileSameNamespace() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                string %Foo
+                
+                @myTrait(ref: com.foo#%Foo)
+                structure Bar {
+                    foo: %Foo
+                }
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @myTrait(ref: com.foo#%Foo)
+                structure Abc {
+                    foo: %Foo
+                }
+                """);
+        var result = getEdits("Baz", twp1, twp2);
+
+        assertHasEditsForAllPositions(result, twp1, twp2);
+
+        for (var workspaceEdit : result.edits) {
+            var edited0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edited0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    @trait
+                    structure myTrait {
+                        @idRef
+                        ref: String
+                    }
+                
+                    string Baz
+                    
+                    @myTrait(ref: com.foo#Baz)
+                    structure Bar {
+                        foo: Baz
+                    }
+                    """));
+            var edited1 = getEditedText(result.workspace, workspaceEdit, "model-1.smithy");
+            assertThat(edited1, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    @myTrait(ref: com.foo#Baz)
+                    structure Abc {
+                        foo: Baz
+                    }
+                    """));
+        }
+    }
+
+    @Test
+    public void differentNamespaces() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                structure %Foo {}
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                use com.foo#%Foo
+                
+                structure Bar {
+                    foo: %Foo
+                }
+                """);
+        var result = getEdits("Baz", twp1, twp2);
+
+        assertHasEditsForAllPositions(result, twp1, twp2);
+
+        for (var workspaceEdit : result.edits) {
+            var edited0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edited0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    structure Baz {}
+                    """));
+
+            var edited1 = getEditedText(result.workspace, workspaceEdit, "model-1.smithy");
+            assertThat(edited1, stringEquals("""
+                    $version: "2"
+                    namespace com.bar
+                    
+                    use com.foo#Baz
+                    
+                    structure Bar {
+                        foo: Baz
+                    }
+                    """));
+        }
+    }
+
+    @Test
+    public void localConflicts() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                structure %Foo {}
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                use com.foo#%Foo
+                
+                structure Bar {
+                    foo: %Foo
+                }
+                
+                string Baz
+                """);
+        var result = getEdits("Baz", twp1, twp2);
+
+        assertHasEditsForAllPositions(result, twp1, twp2);
+
+        for (var workspaceEdit : result.edits) {
+            var edited0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edited0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    structure Baz {}
+                    """));
+
+            var edited1 = getEditedText(result.workspace, workspaceEdit, "model-1.smithy");
+            // Note: Formatter can take care of cleaning this up.
+            assertThat(edited1, stringEquals("""
+                    $version: "2"
+                    namespace com.bar
+                    
+                    
+                    
+                    structure Bar {
+                        foo: com.foo#Baz
+                    }
+                    
+                    string Baz
+                    """));
+        }
+    }
+
+    @Test
+    public void importConflicts() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                structure %Foo {}
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                use com.foo#%Foo
+                use com.baz#Baz
+                
+                structure Bar {
+                    foo: %Foo
+                    baz: Baz
+                }
+                """);
+        var twp3 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.baz
+                
+                structure Baz {}
+                """);
+        var result = getEdits("Baz", twp1, twp2, twp3);
+
+        assertHasEditsForAllPositions(result, twp1, twp2, twp3);
+
+        for (var workspaceEdit : result.edits) {
+            var edit0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edit0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    structure Baz {}
+                    """));
+            var edit1 = getEditedText(result.workspace, workspaceEdit, "model-1.smithy");
+            assertThat(edit1, stringEquals("""
+                    $version: "2"
+                    namespace com.bar
+                    
+                    
+                    use com.baz#Baz
+                    
+                    structure Bar {
+                        foo: com.foo#Baz
+                        baz: Baz
+                    }
+                    """));
+
+            String uri = result.workspace.getUri("model-2.smithy");
+            var unrelatedEdit = workspaceEdit.getChanges().get(uri);
+            assertThat(unrelatedEdit, nullValue());
+        }
+    }
+
+    @Test
+    public void importConflictsInDefinitionFile() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                use com.bar#Bar
+                
+                structure %Foo {
+                    foo: %Foo
+                    bar: Bar
+                }
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                structure Bar {}
+                """);
+        var result = getEdits("Bar", twp1, twp2);
+
+        assertHasEditsForAllPositions(result, twp1, twp2);
+
+        for (var workspaceEdit : result.edits) {
+            var edit0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edit0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    
+                    
+                    structure Bar {
+                        foo: Bar
+                        bar: com.bar#Bar
+                    }
+                    """));
+
+            String uri = result.workspace.getUri("model-1.smithy");
+            var unrelatedEdit = workspaceEdit.getChanges().get(uri);
+            assertThat(unrelatedEdit, nullValue());
+        }
+    }
+
+    @Test
+    public void importConflictsInSameNamespaceFile() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                structure %Foo {}
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                structure Bar {}
+                """);
+        var twp3 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                use com.bar#Bar
+                
+                structure Baz {
+                    foo: %Foo
+                    bar: Bar
+                }
+                """);
+        var result = getEdits("Bar", twp1, twp2, twp3);
+
+        assertHasEditsForAllPositions(result, twp1, twp2, twp3);
+
+        for (var workspaceEdit : result.edits) {
+            var edit0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edit0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    structure Bar {}
+                    """));
+
+            String uri = result.workspace.getUri("model-1.smithy");
+            var unrelatedEdit = workspaceEdit.getChanges().get(uri);
+            assertThat(unrelatedEdit, nullValue());
+
+            var edit2 = getEditedText(result.workspace, workspaceEdit, "model-2.smithy");
+            assertThat(edit2, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    use com.bar#Bar
+                    
+                    structure Baz {
+                        foo: com.foo#Bar
+                        bar: Bar
+                    }
+                    """));
+        }
+    }
+
+    @Test
+    public void importConflictsAcrossFiles() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                use com.bar#Bar
+                
+                structure %Foo {}
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                use com.foo#%Foo
+                
+                structure Bar {
+                    foo: %Foo
+                }
+                """);
+        var twp3 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                use com.bar#Bar
+                
+                structure A {
+                    foo: %Foo
+                    bar: Bar
+                }
+                """);
+        var twp4 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.baz
+                
+                use com.foo#%Foo
+                use com.bar#Bar
+                
+                structure B {
+                    foo: %Foo
+                    bar: Bar
+                }
+                """);
+        var result = getEdits("Bar", twp1, twp2, twp3, twp4);
+
+        assertHasEditsForAllPositions(result, twp1, twp2, twp3, twp4);
+
+        for (var workspaceEdit : result.edits) {
+            var edit0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edit0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+
+
+
+                    structure Bar {}
+                    """));
+
+            var edit1 = getEditedText(result.workspace, workspaceEdit, "model-1.smithy");
+            assertThat(edit1, stringEquals("""
+                    $version: "2"
+                    namespace com.bar
+                    
+                    
+                    
+                    structure Bar {
+                        foo: com.foo#Bar
+                    }
+                    """));
+
+            var edit2 = getEditedText(result.workspace, workspaceEdit, "model-2.smithy");
+            assertThat(edit2, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    use com.bar#Bar
+                    
+                    structure A {
+                        foo: com.foo#Bar
+                        bar: Bar
+                    }
+                    """));
+
+            var edit3 = getEditedText(result.workspace, workspaceEdit, "model-3.smithy");
+            assertThat(edit3, stringEquals("""
+                    $version: "2"
+                    namespace com.baz
+                    
+                    
+                    use com.bar#Bar
+                    
+                    structure B {
+                        foo: com.foo#Bar
+                        bar: Bar
+                    }
+                    """));
+        }
+    }
+
+    @Test
+    public void importConflictsInTraitsSimple() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                use com.bar#Bar
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                structure %Foo {
+                    @myTrait(ref: Bar$bar)
+                    bar: Bar
+                }
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                use com.foo#myTrait
+                
+                structure Bar {
+                    bar: Bar
+                }
+                """);
+        var result = getEdits("Bar", twp1, twp2);
+
+        assertHasEditsForAllPositions(result, twp1, twp2);
+        for (var workspaceEdit : result.edits) {
+            var edit0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edit0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    
+                    
+                    @trait
+                    structure myTrait {
+                        @idRef
+                        ref: String
+                    }
+                    
+                    structure Bar {
+                        @myTrait(ref: com.bar#Bar$bar)
+                        bar: com.bar#Bar
+                    }
+                    """));
+        }
+    }
+
+    @Test
+    public void importConflictsInTraits() {
+        var twp1 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                use com.bar#Bar
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: Bar)
+                structure %Foo {
+                    @myTrait(ref: com.bar#Bar)
+                    bar: Bar
+                
+                    @myTrait(ref: com.bar#Bar$bar)
+                    bar2: com.bar#Bar
+                
+                    @myTrait(ref: Bar$bar)
+                    foo: %Foo
+                
+                    @myTrait(ref: %Foo$bar)
+                    foo2: com.foo#%Foo
+                
+                    @myTrait(ref: com.foo#%Foo$bar)
+                    foo3: %Foo
+                }
+                """);
+        var twp2 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.bar
+                
+                use com.foo#myTrait
+                use com.foo#%Foo
+                
+                @myTrait(ref: %Foo)
+                structure Bar {
+                    @myTrait(ref: com.foo#%Foo)
+                    foo: %Foo
+                
+                    @myTrait(ref: com.foo#%Foo$bar)
+                    foo2: com.foo#%Foo
+                
+                    @myTrait(ref: Foo$bar)
+                    foo3: %Foo
+                
+                    bar: Bar
+                }
+                """);
+        var twp3 = TextWithPositions.from("""
+                $version: "2"
+                namespace com.baz
+                
+                use com.foo#myTrait
+                use com.foo#%Foo
+                use com.bar#Bar
+                
+                @myTrait(ref: %Foo)
+                structure Baz {
+                    @myTrait(ref: com.foo#%Foo)
+                    foo: %Foo
+                
+                    @myTrait(ref: com.foo#%Foo$bar)
+                    bar: Bar
+                
+                    @myTrait(ref: %Foo$bar)
+                    foo2: com.foo#%Foo
+                }
+                """);
+        var result = getEdits("Bar", twp1, twp2, twp3);
+
+        assertHasEditsForAllPositions(result, twp1, twp2, twp3);
+
+        for (var workspaceEdit : result.edits) {
+            var edit0 = getEditedText(result.workspace, workspaceEdit, "model-0.smithy");
+            assertThat(edit0, stringEquals("""
+                    $version: "2"
+                    namespace com.foo
+                    
+                    
+                    
+                    @trait
+                    structure myTrait {
+                        @idRef
+                        ref: String
+                    }
+                    
+                    @myTrait(ref: com.bar#Bar)
+                    structure Bar {
+                        @myTrait(ref: com.bar#Bar)
+                        bar: com.bar#Bar
+                    
+                        @myTrait(ref: com.bar#Bar$bar)
+                        bar2: com.bar#Bar
+                    
+                        @myTrait(ref: com.bar#Bar$bar)
+                        foo: Bar
+                    
+                        @myTrait(ref: Bar$bar)
+                        foo2: com.foo#Bar
+                    
+                        @myTrait(ref: com.foo#Bar$bar)
+                        foo3: Bar
+                    }
+                    """));
+
+            var edit1 = getEditedText(result.workspace, workspaceEdit, "model-1.smithy");
+            assertThat(edit1, stringEquals("""
+                    $version: "2"
+                    namespace com.bar
+                    
+                    use com.foo#myTrait
+                    
+                    
+                    @myTrait(ref: com.foo#Bar)
+                    structure Bar {
+                        @myTrait(ref: com.foo#Bar)
+                        foo: com.foo#Bar
+                    
+                        @myTrait(ref: com.foo#Bar$bar)
+                        foo2: com.foo#Bar
+                    
+                        @myTrait(ref: com.foo#Bar$bar)
+                        foo3: com.foo#Bar
+                    
+                        bar: Bar
+                    }
+                    """));
+
+            var edit2 = getEditedText(result.workspace, workspaceEdit, "model-2.smithy");
+            assertThat(edit2, stringEquals("""
+                    $version: "2"
+                    namespace com.baz
+                    
+                    use com.foo#myTrait
+                    
+                    use com.bar#Bar
+                    
+                    @myTrait(ref: com.foo#Bar)
+                    structure Baz {
+                        @myTrait(ref: com.foo#Bar)
+                        foo: com.foo#Bar
+                    
+                        @myTrait(ref: com.foo#Bar$bar)
+                        bar: Bar
+                    
+                        @myTrait(ref: com.foo#Bar$bar)
+                        foo2: com.foo#Bar
+                    }
+                    """));
+        }
+    }
+
+    @Test
+    public void multipleEditsOnSameLine() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                
+                    @idRef
+                    ref2: String
+                }
+                
+                @myTrait(ref: %Foo, ref2: %Foo)
+                structure %Foo {
+                    foo: %Foo
+                }
+                """);
+        var result = getEdits("A", twp);
+
+        assertHasEditsForAllPositions(result, twp);
+
+        assertAllEditsMake(result, """
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                
+                    @idRef
+                    ref2: String
+                }
+                
+                @myTrait(ref: A, ref2: A)
+                structure A {
+                    foo: A
+                }
+                """);
+    }
+
+    @Test
+    public void stringIdRef() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: "%com.foo#Foo")
+                structure %Foo {
+                    @myTrait(ref: "%com.foo#Foo$foo")
+                    foo: String
+                }
+                """);
+        var result = getEdits("Bar", twp);
+
+        assertHasEditsForAllPositions(result, twp);
+        assertAllEditsMake(result, """
+                $version: "2"
+                namespace com.foo
+                
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+                
+                @myTrait(ref: "com.foo#Bar")
+                structure Bar {
+                    @myTrait(ref: "com.foo#Bar$foo")
+                    foo: String
+                }
+                """);
+    }
+
+    @Test
+    public void prepare() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+
+                @trait
+                structure myTrait {
+                    @idRef
+                    ref: String
+                }
+
+                @myTrait(ref: %com.foo#%Foo%$foo)
+                structure %Foo% {
+                    @myTrait(ref: %Foo%$foo)
+                    foo: %Foo%
+                }
+                
+                @myTrait(ref: %Foo%)
+                string Bar
+                """);
+        var onNs = twp.positions()[0];
+        var onAbsNameWithMember = twp.positions()[1];
+        var onAbsNameWithMemberEnd = twp.positions()[2];
+        var onDef = twp.positions()[3];
+        var onDefEnd = twp.positions()[4];
+        var onRelNameWithMember = twp.positions()[5];
+        var onRelNameWithMemberEnd = twp.positions()[6];
+        var onTarget = twp.positions()[7];
+        var onTargetEnd = twp.positions()[8];
+        var onRelName = twp.positions()[9];
+        var onRelNameEnd = twp.positions()[10];
+
+        TestWorkspace workspace = TestWorkspace.singleModel(twp.text());
+        Project project = ProjectTest.load(workspace.getRoot());
+        String uri = workspace.getUri("main.smithy");
+        IdlFile idlFile = (IdlFile) project.getProjectFile(uri);
+        RenameHandler handler = new RenameHandler(project, idlFile);
+
+        var rangeOnNs = handler.prepare(RequestBuilders.positionRequest()
+                .uri(uri).position(onNs).buildPrepareRename());
+        var rangeOnAbsNameWithMember = handler.prepare(RequestBuilders.positionRequest()
+                .uri(uri).position(onAbsNameWithMember).buildPrepareRename());
+        var rangeOnDef = handler.prepare(RequestBuilders.positionRequest()
+            .uri(uri).position(onDef).buildPrepareRename());
+        var rangeOnRelNameWithMember = handler.prepare(RequestBuilders.positionRequest()
+            .uri(uri).position(onRelNameWithMember).buildPrepareRename());
+        var rangeOnTarget = handler.prepare(RequestBuilders.positionRequest()
+            .uri(uri).position(onTarget).buildPrepareRename());
+        var rangeOnRelName = handler.prepare(RequestBuilders.positionRequest()
+            .uri(uri).position(onRelName).buildPrepareRename());
+
+        assertThat(rangeOnNs, equalTo(new Range(onAbsNameWithMember, onAbsNameWithMemberEnd)));
+        assertThat(rangeOnAbsNameWithMember, equalTo(new Range(onAbsNameWithMember, onAbsNameWithMemberEnd)));
+        assertThat(rangeOnDef, equalTo(new Range(onDef, onDefEnd)));
+        assertThat(rangeOnRelNameWithMember, equalTo(new Range(onRelNameWithMember, onRelNameWithMemberEnd)));
+        assertThat(rangeOnTarget, equalTo(new Range(onTarget, onTargetEnd)));
+        assertThat(rangeOnRelName, equalTo(new Range(onRelName, onRelNameEnd)));
+    }
+
+    @Test
+    public void invalidShapeId() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                string %Foo
+                """);
+
+        assertThat(() -> getEdits("123", twp), throwsWithMessage(containsString("id would be invalid")));
+    }
+
+    @Test
+    public void referenceInJar() {
+        var twp = TextWithPositions.from("""
+                $version: "2"
+                namespace com.foo
+                
+                structure Foo {
+                    foo: %String
+                }
+                """);
+
+        assertThat(() -> getEdits("Bar", twp), throwsWithMessage(containsString("jar")));
+    }
+
+    private static void assertHasEditsForAllPositions(GetEditsResult result, TextWithPositions... twps) {
+        int sum = 0;
+        for (TextWithPositions twp : twps) {
+            sum += twp.positions().length;
+        }
+        assertThat(result.edits, hasSize(sum));
+    }
+
+    private static void assertAllEditsMake(GetEditsResult result, String expected) {
+        assertThat(result.edits, not(empty()));
+
+        for (var edit : result.edits) {
+            var editedText = getEditedText(result.workspace, edit, "model-0.smithy");
+            assertThat(editedText, stringEquals(expected));
+        }
+    }
+
+    private static String getEditedText(TestWorkspace workspace, WorkspaceEdit edit, String filename) {
+        String uri = workspace.getUri(filename);
+        var textEdits = edit.getChanges().get(uri);
+        assertThat(textEdits, notNullValue());
+        assertThat(textEdits, not(empty()));
+
+        String text = workspace.readFile(filename);
+        var document = Document.of(text);
+        // Edits have to be applied in reverse order so that an edit earlier in the
+        // file doesn't clobber the range a later edit would occupy.
+        textEdits.sort((l, r) -> {
+            int lIdx = document.indexOfPosition(l.getRange().getStart());
+            int rIdx = document.indexOfPosition(r.getRange().getStart());
+            return Integer.compare(rIdx, lIdx);
+        });
+
+        for (var textEdit : textEdits) {
+            var s = document.indexOfPosition(textEdit.getRange().getStart());
+            var e = document.indexOfPosition(textEdit.getRange().getEnd());
+            var span = document.copySpan(s, e);
+            document.applyEdit(textEdit.getRange(), textEdit.getNewText());
+            var tmp = document.copyText();
+            System.out.println();
+        }
+        return document.copyText();
+    }
+
+    private record GetEditsResult(TestWorkspace workspace, List<WorkspaceEdit> edits) {}
+
+    private static GetEditsResult getEdits(String newName, TextWithPositions... twps) {
+        var files = Arrays.stream(twps).map(TextWithPositions::text).toArray(String[]::new);
+        TestWorkspace workspace = TestWorkspace.multipleModels(files);
+        Project project = ProjectTest.load(workspace.getRoot());
+        List<WorkspaceEdit> edits = new ArrayList<>();
+        for (int i = 0; i < twps.length; i++) {
+            String uri = workspace.getUri("model-" + i + ".smithy");
+            IdlFile idlFile = (IdlFile) project.getProjectFile(uri);
+            RenameHandler handler = new RenameHandler(project, idlFile);
+            for (Position position : twps[i].positions()) {
+                var params = RequestBuilders.positionRequest()
+                        .uri(uri)
+                        .position(position)
+                        .buildRename(newName);
+                var edit = handler.handle(params);
+                edits.add(edit);
+            }
+        }
+        return new GetEditsResult(workspace, edits);
+    }
+}


### PR DESCRIPTION
Adds support for 'textDocument/references', 'textDocument/rename', and
'textDocument/prepareRename'. These all work very similarly, so I
implemented them together.

This implementation only works for root shapes, not members or resource
identifiers/properties (which I call resource fields for brevity).
Originally I intended to make it work for members, but for 'complete'
member support, you really need to support resource fields, otherwise if
you tried to rename a member, it wouldn't rename the resource field it
references, and finding references wouldn't show fully accurate
information. The problem is, the relationship between members and
resource fields can be implicit, and/or determined by a number of
different traits (`resourceIdentifier`, `property`, `references`,
`nestedProperties`). And some of these traits refer to the resource
field by string name. Current KnowledgeIndex implementations don't
support going from an arbitrary member -> field bindings and back. Plus,
we can't reliably use KnowledgeIndicies because they usually operate on
a complete, valid model, whereas the language server wants to operate on
the minimum subset of a possibly invalid model.

I think it would be possible still to support members in the future,
either with some clever code in the language server or enhancements to
the smithy library, but I didn't want to block rename/references for
regular shapes on that.

Some specific implementation details to note:
1. Rename/References throw ResponseErrorException on an unsupported
   position (like a member name), or when the rename would be invalid
   (i.e. renaming a shape from a dependency, or providing an invalid
   shape name). This is what the spec says you should do, and we should
   update other features to do the same.
2. Rename disambiguates shapes that would be conflicting after the rename
   by using an absolute shape id, and removes conflicting use statements.
3. Rename/References both work on references to members of the target
   shape, i.e. `com.foo#Foo$bar`, only if the request position is before
   the `$`, otherwise it assumes you're getting the reference of a
   member.
4. Prepare returns the range of the identifier to be renamed (or throws
   an error as specified in 1.), so if you go to rename `com.foo#Bar`,
   the rename range will be the range of `Bar`.

Other notable changes:
1. Changed `DocumentId` to only have distinct types for root shapes and
   members. The type will be `ROOT` when the cursor is in any part of
   the shape id before a member, and `MEMBER` only when the cursor is
   actually within the member part of the shape id. The rest of the
   other possible id types didn't seem to be useful enough to keep.
2. Added a `line` field to Syntax.Node.Str, which makes it _much_
   more efficient to get the range of a Str or Ident.
3. Fixed an issue in TextWithPositions when there are multiple positions
   on the same line.

Rev: Fix shape search resolution

Fixes an issue with ShapeSearch::findShape where the local namespace was
checked before imports. It was inconsistent with the way the model
loader resolves shapes, so you could end up jumping to the wrong
definition/references, or renaming the wrong shape.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
