### PR TITLE
Remove diagnostics from hover

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -678,8 +678,7 @@ public class SmithyLanguageServer implements
             case IdlFile idlFile -> {
                 Project project = projectAndFile.project();
 
-                // TODO: Abstract away passing minimum severity
-                var handler = new HoverHandler(project, idlFile, this.serverOptions.getMinimumSeverity());
+                var handler = new HoverHandler(project, idlFile);
                 yield CompletableFuture.supplyAsync(() -> handler.handle(params));
             }
             case BuildFile buildFile -> {

--- a/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/language/HoverHandlerTest.java
@@ -23,7 +23,6 @@ import software.amazon.smithy.lsp.project.IdlFile;
 import software.amazon.smithy.lsp.project.Project;
 import software.amazon.smithy.lsp.project.ProjectTest;
 import software.amazon.smithy.lsp.project.SmithyFile;
-import software.amazon.smithy.model.validation.Severity;
 
 public class HoverHandlerTest {
     @Test
@@ -372,7 +371,7 @@ public class HoverHandlerTest {
         SmithyFile smithyFile = (SmithyFile) project.getProjectFile(uri);
 
         List<String> hover = new ArrayList<>();
-        HoverHandler handler = new HoverHandler(project, (IdlFile) smithyFile, Severity.WARNING);
+        HoverHandler handler = new HoverHandler(project, (IdlFile) smithyFile);
         for (Position position : positions) {
             HoverParams params = RequestBuilders.positionRequest()
                     .uri(uri)


### PR DESCRIPTION
Diagnostics are already displayed by clients when hovering, so adding them in our hover implementation duplicates them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
