### PR TITLE
Add missing modules to runtime

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ jar {
 
 runtime {
     addOptions("--compress", "2", "--strip-debug", "--no-header-files", "--no-man-pages")
-    addModules("java.logging")
+    addModules("java.logging", "java.naming", "java.xml", "jdk.crypto.ec")
 
     launcher {
         jvmArgs = [


### PR DESCRIPTION
Updates the runtime plugin config to include the same modules the smithy-cli does:
https://github.com/smithy-lang/smithy/blob/fb9ef6dafe89742eefb87f0072b4c7762afd70d9/smithy-cli/build.gradle.kts#L99. Otherwise, we get some class defs not found when resolving dependencies. I don't have a good idea for how to avoid the duplication between the repos.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
