### PR TITLE
Cleanup build script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ println("Smithy Language Server version: '${version}'")
 
 val stagingDirectory = layout.buildDirectory.dir("staging")
 val releaseChangelogFile = layout.buildDirectory.file("resources/RELEASE_CHANGELOG.md").get()
+val smithyVersion: String by project
 
 plugins {
     java
@@ -50,10 +51,10 @@ repositories {
 
 dependencies {
     implementation("org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1")
-    implementation("software.amazon.smithy:smithy-build:[smithyVersion, 2.0[")
-    implementation("software.amazon.smithy:smithy-cli:[smithyVersion, 2.0[")
-    implementation("software.amazon.smithy:smithy-model:[smithyVersion, 2.0[")
-    implementation("software.amazon.smithy:smithy-syntax:[smithyVersion, 2.0[")
+    implementation("software.amazon.smithy:smithy-build:[$smithyVersion, 2.0[")
+    implementation("software.amazon.smithy:smithy-cli:[$smithyVersion, 2.0[")
+    implementation("software.amazon.smithy:smithy-model:[$smithyVersion, 2.0[")
+    implementation("software.amazon.smithy:smithy-syntax:[$smithyVersion, 2.0[")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
     testImplementation("org.hamcrest:hamcrest:2.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,6 @@ plugins {
     id("application")
 
     id("maven-publish")
-    id("com.palantir.git-version") version "0.12.3"
     id("checkstyle")
     id("org.jreleaser") version "1.13.0"
 
@@ -47,9 +46,6 @@ plugins {
     id("com.dua3.gradle.runtime") version "1.13.1-patch-1"
 }
 
-
-val gitVersion: groovy.lang.Closure<String> by extra
-version = gitVersion().replaceFirst("v", "")
 
 // Reusable license copySpec for building JARs
 val licenseSpec = copySpec {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,8 +126,6 @@ dependencies {
     testImplementation("org.hamcrest:hamcrest:2.2")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
-    checkstyle("com.puppycrawl.tools:checkstyle:${checkstyle.toolVersion}")
 }
 
 tasks.withType<Javadoc> {


### PR DESCRIPTION
Our build script was a mess and it has been bugging me for a while, so I'm
finally cleaning it up. I mostly reorganized things, and removed unnecessary
configuration, but there are some minor changes to note:
- Got rid of the git-version plugin, which shouldn't be necessary since we
  use the VERSION file to manage the project version.
- Got rid of the manual checkstyle dependency, since what we were setting
   it to was already the default.
- Changed test logging to only log failed and skipped, instead of passed and
   stdout/err, which should reduce some noise.
- Fixed the dependency declaration for smithy libraries, which weren't using
   string interpolation, so were literally "[smithyVersion, 2.0[". Either that was
   a thing you could do in groovy, or it's been busted since 2023. Yikes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
