### PR TITLE
diagnostics: add hint to message, if present

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/diagnostics/SmithyDiagnostics.java
+++ b/src/main/java/software/amazon/smithy/lsp/diagnostics/SmithyDiagnostics.java
@@ -208,8 +208,19 @@ public final class SmithyDiagnostics {
                 default -> DiagnosticSeverity.Hint;
             };
             var diagnosticRange = getDiagnosticRange(event);
-            var message = event.getId() + ": " + event.getMessage();
-            return new Diagnostic(diagnosticRange, message, diagnosticSeverity, "Smithy");
+
+            var message =
+                new StringBuilder(event.getId())
+                    .append(": ")
+                    .append(event.getMessage());
+
+            event.getHint().ifPresent(hint ->
+                message
+                    .append("\n\nHint: ")
+                    .append(hint)
+            );
+
+            return new Diagnostic(diagnosticRange, message.toString(), diagnosticSeverity, "Smithy");
         }
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/diagnostics/SmithyDiagnostics.java
+++ b/src/main/java/software/amazon/smithy/lsp/diagnostics/SmithyDiagnostics.java
@@ -208,19 +208,19 @@ public final class SmithyDiagnostics {
                 default -> DiagnosticSeverity.Hint;
             };
             var diagnosticRange = getDiagnosticRange(event);
+            var message = getMessage(event);
+            return new Diagnostic(diagnosticRange, message, diagnosticSeverity, "Smithy");
+        }
+       
+       String HINT_PREFIX = System.lineSeparator() + System.lineSeparator() + "Hint: ";
 
-            var message =
-                new StringBuilder(event.getId())
-                    .append(": ")
-                    .append(event.getMessage());
+        private static String getMessage(ValidationEvent event) {
+            var hint = event.getHint().orElse(null);
+            if (hint == null) {
+                return event.getId() + ": " + event.getMessage();
+            }
 
-            event.getHint().ifPresent(hint ->
-                message
-                    .append("\n\nHint: ")
-                    .append(hint)
-            );
-
-            return new Diagnostic(diagnosticRange, message.toString(), diagnosticSeverity, "Smithy");
+            return event.getId() + ": " + event.getMessage() + HINT_PREFIX + hint;
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a diagnostic's hint to the message, if there is one present.

Tested manually. I didn't find any real validations in the Smithy repo that would include a hint, so I don't see an easy way to test this with real diagnostics. Built-in validators like `EmitEachSelectorValidator` also don't support adding hints.

Is it OK to go without a test? `toDiagnostic` is in a private interface too, so I can't unit test it without refactoring.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
