### PR TITLE
Fix jar uri conversion

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
+++ b/src/main/java/software/amazon/smithy/lsp/SmithyLanguageServer.java
@@ -369,7 +369,7 @@ public class SmithyLanguageServer implements
             return completedFuture(projectAndFile.file().document().copyText());
         } else {
             // Technically this can throw if the uri is invalid
-            return completedFuture(IoUtils.readUtf8Url(LspAdapter.jarUrl(uri)));
+            return completedFuture(IoUtils.readUtf8Url(LspAdapter.smithyJarUriToReadableUrl(uri)));
         }
     }
 

--- a/src/main/java/software/amazon/smithy/lsp/project/ProjectLoader.java
+++ b/src/main/java/software/amazon/smithy/lsp/project/ProjectLoader.java
@@ -211,7 +211,7 @@ public final class ProjectLoader {
         // the model stores jar paths as URIs
         if (LspAdapter.isSmithyJarFile(filePath) || LspAdapter.isJarFile(filePath)) {
             // Technically this can throw
-            String text = IoUtils.readUtf8Url(LspAdapter.jarUrl(filePath));
+            String text = IoUtils.readUtf8Url(LspAdapter.jarModelFilenameToReadableUrl(filePath));
             Document document = Document.of(text);
             consumer.accept(filePath, text, document);
             return;

--- a/src/test/java/software/amazon/smithy/lsp/protocol/LspAdapterTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/protocol/LspAdapterTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package software.amazon.smithy.lsp.protocol;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.junit.jupiter.api.Test;
+
+public class LspAdapterTest {
+    @Test
+    public void jarModelFilenameRoundTrip() {
+        String jarModelFilename = "jar:file:/path%20with%20spaces/foo.jar!/bar.smithy";
+        String jarUri = LspAdapter.toUri(jarModelFilename);
+
+        assertThat(jarUri, equalTo("smithyjar:/path%20with%20spaces/foo.jar!/bar.smithy"));
+        assertThat(LspAdapter.toPath(jarUri), equalTo(jarModelFilename));
+    }
+
+    @Test
+    public void smithyjarRoundTrip() {
+        String jarUri = "smithyjar:/path%20with%20spaces/foo.jar!/bar.smithy";
+        String jarModelFilename = LspAdapter.toPath(jarUri);
+
+        assertThat(jarModelFilename, equalTo("jar:file:/path%20with%20spaces/foo.jar!/bar.smithy"));
+        assertThat(LspAdapter.toUri(jarModelFilename), equalTo(jarUri));
+    }
+
+    @Test
+    public void aggressivelyEncodedSmithyjarRoundTrip() {
+        String encodedJarUri = "smithyjar:/path%20with%20spaces/foo.jar%21/bar.smithy";
+        String jarModelFilename = LspAdapter.toPath(encodedJarUri);
+
+        assertThat(jarModelFilename, equalTo("jar:file:/path%20with%20spaces/foo.jar!/bar.smithy"));
+        assertThat(LspAdapter.toUri(jarModelFilename), equalTo("smithyjar:/path%20with%20spaces/foo.jar!/bar.smithy"));
+    }
+
+    @Test
+    public void aggressivelyEncodedSmithyJarToUrl() {
+        String encodedJarUri = "smithyjar:/path%20with%20spaces/foo.jar%21/bar.smithy";
+
+        assertDoesNotThrow(() -> LspAdapter.smithyJarUriToReadableUrl(encodedJarUri));
+    }
+}


### PR DESCRIPTION
The language server has to convert to and from LSP's URIs and the Smithy model's source location filenames. The filenames used for files in jars are actually URIs in the form `jar:file/foo.jar!/bar.smithy` - obviously there isn't an actual file path to a file within a jar.

Because LSP's URIs and these Jar URIs are URIs, they're percent-encoded. When we convert from a regular file URI -> filename, `Path.of(URI).toString()` makes sure the filename ends up properly decoded, regardless of how the client encoded the URI. However, when going from jar file URI -> jar file filename (as it appears in the model), we don't want to decode the URI (because the filename is encoded in the model).

This should be easy, but since some clients encode the URI differently, the URI sent by the client might not be encoded the same way it is in the model filename. In particular, VSCode is quite aggresive in its encoding, and encodes the `!` in the jar URI. To handle this, we were decoding the LSP URI, but if the URI has other special characters, like spaces, those would also be decoded. I'm pretty sure this would always be an issue on windows too, since the `:` in `C:` would be encoded.

The problem hasn't come up yet, because who puts special characters in file/directory names? However, when trying to autodownload our new standalone installations in the VSCode extension, I found that extensions' storage directories are under `/Application Support/` on Mac. So we need to fix this in order to autodownload the language server.

To fix this, I updated the implementation of a few methods in LspAdapter. Most notable is the new `smithyJarUriToJarModelFilename` method which takes an LSP jar URI and turns it into a Java URI that can properly `toString()` into the model filename, or `toURL()` into a URL that can be used to read the contents of the file. The method has a comment that explains how it works - it's really a hack.

We really shouldn't be using strings to represent URIs and paths at all, but at some point we still need to go back and forth between LSP URI and model filename, so I'm not sure if that would fix the problem, or just move it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
