### PR TITLE
Simplify installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ For example, on an ARM Mac:
 
 ```shell
 curl -o download.zip -L "https://github.com/smithy-lang/smithy-language-server/releases/latest/download/smithy-language-server-darwin-aarch64.zip"
-unzip download.zip
-smithy-language-server-darwin-aarch64/bin/smithy-language-server --help
+unzip download.zip -d smithy-language-server
+smithy-language-server/bin/smithy-language-server --help
 ```
 
 Run smithy-language-server by running the launch script with no arguments - this


### PR DESCRIPTION
Simplifies the installation process of the runtime images we release, for humans as well as editor plugins that want to automatically install/update the language server.

First thing I did was change the name of the release artifact for windows x64 from `windows-x64` to `windows-x86_64`. They generally refer to the same thing, and both the linux and mac x64 artifacts use x86_64, so automated downloads don't have to special case windows.

The next thing I did was make it so the zips we release of the runtime images have a flat directory structure. By default (and seemingly with no way to change it), the runtime plugin creates a zip where the first entry is the directory being zipped. For example:

```
> unzip smithy-language-server-darwin-aarch64.zip
> ls
smithy-language-server-darwin-aarch64.zip
smithy-language-server-darwin-aarch64/
```

This commit makes it:
```
> unzip smithy-language-server-darwin-aarch64.zip
> ls
smithy-language-server-darwin-aarch64.zip
bin/
conf/
... you get the idea
```

Since the plugin doesn't provide you with a way to do this, I had to use some gradle wizardry to essentially override the default `runtimeZip` task so the task dependency graph stayed the same.

The comment in build.gradle.kts has more details on how it works, but it basically just makes a custom Zip task for each target.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
