### PR TITLE
Don't build an uberjar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,18 +129,6 @@ tasks {
         dependsOn(createProperties)
     }
 
-    jar {
-        from(configurations.runtimeClasspath.get().map { zipTree(it) }) {
-            // Don't need signature files, and we don't use modules
-            exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "**/module-info.class")
-            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-        }
-
-        manifest {
-            attributes("Main-Class" to "software.amazon.smithy.lsp.Main")
-        }
-    }
-
     checkstyleTest {
         enabled = false
     }
@@ -215,7 +203,7 @@ checkstyle {
 }
 
 runtime {
-    addOptions("--compress", "2", "--strip-debug", "--no-header-files", "--no-man-pages")
+    addOptions("--compress", "zip-6", "--strip-debug", "--no-header-files", "--no-man-pages")
     addModules("java.logging", "java.naming", "java.xml", "jdk.crypto.ec")
 
     launcher {


### PR DESCRIPTION
The default jar we've been building since the beginning of the language server was an uberjar containing all our dependencies. This is also the jar we published to Maven Central, and (more recently) the jar we have included in the runtime images.

For publishing and the runtime image, this is definitely wrong. Running the language server with coursier, which seems common and is also what the vscode extension currently does, means coursier will resolve and fetch dependencies for no reason. For the runtime image, it means we have basically duplicated all the dependency jars, increasing download size for no reason. Both probably incur a startup penalty too.

I'm guessing the original reason for this was so you could just do a build and run `java -jar ...` to run the language server. But since we publish to Maven and have the runtime images, I'm not sure what the benefit of keeping the uberjar would be, unless people pull it from Maven without doing dependency resolution.

I decided to just remove the uberjar. If it causes an issue, we can always bring it back and use the shadow plugin or something.

With this change, we got some moderate install size improvements. Around 12-14% depending on the target:
 windows-x64    49M -> 42M
 darwin-aarch64 50M -> 43M
 darwin-x86_64  51M -> 44M
 linux-aarch64  57M -> 50M
 linux-x86_64   58M -> 51M

Side note: A 40-50M install size still annoyed me, so I did some digging and tried a few things. Just smithy-cli and smithy-model make up about 6M, while the language server itself and the rest of our deps all together don't break 3M. Not much we can do here unless the cli changed what is uses (we do duplicate gson, which is shaded in the CLI, but it's only like 300K). Another thing I tried was digging into the JDK modules we link. There's only a few, and they're all quite small, except for 'java.xml' which is like 3M. Unfortunately we do need that at runtime according to my tests. Something uses it. The last thing I tried was increasing the '--compress' jlink option from 6 -> 9, but didn't notice a difference.

Also in this commit I changed the '--compress' option's value. The value '2' is deprecated. 'zip-6' is the same level of compression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
