### PR TITLE
fix: Update GitHub Actions versions and Smithy version check URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,13 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.java }}
+          distribution: corretto
 
       - name: Clean and build
         run: ./gradlew clean build -Plog-tests

--- a/.github/workflows/update-smithy-version.yml
+++ b/.github/workflows/update-smithy-version.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'smithy-lang/smithy-language-server'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Fetch latest smithy version
         id: fetch-latest
         run: |
           echo "latestSmithy=$( \
-            curl -sL https://api.github.com/repos/awslabs/smithy/releases/latest | \
+            curl -sL https://api.github.com/repos/smithy-lang/smithy/releases/latest | \
             jq -r '.tag_name')" >> $GITHUB_OUTPUT
 
       - name: Get current versions


### PR DESCRIPTION
## Summary

Updates the CI and automation workflows to use current GitHub Actions versions and the canonical Smithy repository URL.

## Changes

### `update-smithy-version.yml`
- Update Smithy release check URL from `awslabs/smithy` to `smithy-lang/smithy` (the repo moved to the `smithy-lang` org; GitHub redirects still work but the URL should reference the canonical location)
- Bump `actions/checkout` from v3 to v4

### `ci.yml`
- Bump `actions/checkout` from v2 to v4
- Bump `actions/setup-java` from v1 to v4 with `distribution: corretto`
- This fixes the macOS CI job which fails because `setup-java@v1` sets `JAVA_HOME` to an x64 path on ARM (Apple Silicon) runners

## Testing
- Local build passes: `./gradlew clean build -Plog-tests`
- CI should now pass on all three platforms (ubuntu, windows, macos)