### PR TITLE
Allow newlines in single quotes when parsing string nodes

### DIFF
--- a/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
+++ b/src/main/java/software/amazon/smithy/lsp/syntax/Parser.java
@@ -409,8 +409,9 @@ final class Parser extends SimpleParser {
 
         int last = '"';
 
-        // Potential micro-optimization - only loop while position < line end
-        while (!isNl() && !eof()) {
+        // A quoted string can span multiple lines (NL is a valid quoted_char per the Smithy
+        // grammar), so scan until the closing quote or EOF rather than stopping at the line end.
+        while (!eof()) {
             if (is('"') && last != '\\') {
                 skip(); // '"'
                 int strEnd = position();

--- a/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/IdlParserTest.java
@@ -194,7 +194,7 @@ public class IdlParserTest {
     public void parsesServiceAndResource() {
         String text = """
                 service Foo {
-                    version: "2024-08-15
+                    version: "2024-08-15"
                     operations: [
                         Op1
                         Op2

--- a/src/test/java/software/amazon/smithy/lsp/syntax/NodeParserTest.java
+++ b/src/test/java/software/amazon/smithy/lsp/syntax/NodeParserTest.java
@@ -171,7 +171,9 @@ public class NodeParserTest {
     private static Stream<Arguments> goodStringsProvider() {
         return Stream.of(
                 Arguments.of("\"foo\"", "foo"),
-                Arguments.of("\"\"", "")
+                Arguments.of("\"\"", ""),
+                // A quoted string can span multiple lines (NL is a valid quoted_char).
+                Arguments.of("\"foo\nbar\"", "foo\nbar")
         );
     }
 


### PR DESCRIPTION
*Description of changes:*

Given the valid smithy definition below

```smithy
@documentation(
"A multiline
documentation
string using
single quotes"
)
structure Foo {}
```

The LSP parsing code for string nodes was only parsing to the end of the first line. This resulted in subsequent Nodes being incorrect and would result in a NPE here https://github.com/smithy-lang/smithy-language-server/blob/8dc6c7bad57302fdd4811140330552ca3a36eb3d/src/main/java/software/amazon/smithy/lsp/language/DocumentSymbolHandler.java#L49 

The Smithy IDL grammar does allow for [single quoted strings to contain new lines](https://smithy.io/2.0/spec/idl.html#grammar-token-smithy-QuotedText)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.